### PR TITLE
fix: prettier formatting and commitlint initial push guard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/dependency-review-action@v4
 
       - name: Lint pushed commit messages
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
         run: pnpm exec commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose
 
       - name: Lint PR commit messages

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,1 +1,1 @@
-export { default } from './src/index.js';
+export { default } from "./src/index.js";


### PR DESCRIPTION
Fixes two CI issues from the initial scaffold:

1. **Prettier formatting:** `eslint.config.js` had single quotes instead of double quotes (Prettier default)
2. **Commitlint initial push:** Guards against all-zeros `before` SHA on the first push to a new branch (GitHub sends `0000000000000000000000000000000000000000` as `event.before` for initial pushes)

Both are blocking CI on main and all Dependabot PRs.