### PR TITLE
fix: ignore root package in changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "@benhigham/javascript"
-  ]
+  "ignore": ["@benhigham/javascript"]
 }


### PR DESCRIPTION
The release workflow is failing because changesets can't resolve pnpm `catalog:` protocol references.

**Error:**
```
Package "@benhigham/javascript" must depend on the current version of
"@benhigham/commitlint-config": "1.0.0" vs "catalog:"
```

**Fix:** Add `@benhigham/javascript` (the private root package) to changesets' `ignore` list. Since it's never published, changesets doesn't need to track or validate its internal dependency versions.

**Context:** The root `package.json` uses pnpm catalogs (`catalog:`) for all devDependencies, including the internal `@benhigham/commitlint-config`. Changesets v2.30.0 doesn't resolve catalog references when verifying internal dep consistency.