### PR TITLE
fix: use workspace protocol for internal commitlint-config dep

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@benhigham/javascript"]
+  "ignore": []
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "version": "changeset version"
   },
   "devDependencies": {
-    "@benhigham/commitlint-config": "catalog:",
+    "@benhigham/commitlint-config": "workspace:*",
     "@changesets/changelog-github": "catalog:",
     "@changesets/cli": "catalog:",
     "@commitlint/cli": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@benhigham/commitlint-config':
-      specifier: ^1.0.0
-      version: 1.0.0
     '@changesets/changelog-github':
       specifier: ^0.6.0
       version: 0.6.0
@@ -33,8 +30,8 @@ importers:
   .:
     devDependencies:
       '@benhigham/commitlint-config':
-        specifier: 'catalog:'
-        version: 1.0.0(@commitlint/cli@20.4.4(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3))
+        specifier: workspace:*
+        version: link:packages/commitlint-config
       '@changesets/changelog-github':
         specifier: 'catalog:'
         version: 0.6.0
@@ -303,12 +300,6 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
-
-  '@benhigham/commitlint-config@1.0.0':
-    resolution: {integrity: sha512-e6MvrTVvARSGSWweR9yMjp04sNC8409v3LeUTosMsw7Or2TdD4a9yz+wf1Ob/imQqp7BcrAPgJVNjOo4Ijvu2A==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      '@commitlint/cli': '>=20.0.0'
 
   '@cacheable/memory@2.0.8':
     resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
@@ -3861,12 +3852,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-
-  '@benhigham/commitlint-config@1.0.0(@commitlint/cli@20.4.4(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3))':
-    dependencies:
-      '@commitlint/cli': 20.4.4(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
-      '@commitlint/config-conventional': 20.4.4
-      '@commitlint/format': 20.4.4
 
   '@cacheable/memory@2.0.8':
     dependencies:


### PR DESCRIPTION
Follow-up to #8. The `ignore` approach failed because changesets doesn't include the root package in its package graph:

```
The package "@benhigham/javascript" is specified in the `ignore` option
but it is not found in the project
```

**Fix:** Switch `@benhigham/commitlint-config` from `catalog:` to `workspace:*` in the root `package.json`. Both pnpm and changesets understand `workspace:*`. The catalog entry remains for other packages that reference it.

**What changed:**
- `package.json`: `@benhigham/commitlint-config` → `workspace:*`
- `.changeset/config.json`: reverted `ignore` to empty array