### PR TITLE
fix(deps): override lodash to 4.17.23 for prototype pollution CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "release": "changeset publish",
     "version": "changeset version"
   },
+  "pnpm": {
+    "overrides": {
+      "lodash@<4.17.23": "4.17.23"
+    }
+  },
   "devDependencies": {
     "@benhigham/commitlint-config": "workspace:*",
     "@changesets/changelog-github": "catalog:",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -34,7 +34,7 @@
     "stylelint-high-performance-animation": "^2.0.0",
     "stylelint-media-use-custom-media": "^4.0.0",
     "stylelint-no-indistinguishable-colors": "^2.3.1",
-    "stylelint-no-unresolved-module": "^2.4.0",
+    "stylelint-no-unresolved-module": "^2.5.0",
     "stylelint-no-unsupported-browser-features": "^8.0.4",
     "stylelint-order": "^7.0.0",
     "stylelint-plugin-use-baseline": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ catalogs:
       specifier: ^2.8.17
       version: 2.8.17
 
+overrides:
+  lodash@<4.17.23: 4.17.23
+
 importers:
 
   .:
@@ -194,7 +197,7 @@ importers:
         specifier: ^2.3.1
         version: 2.3.1(stylelint@17.4.0(typescript@5.9.3))
       stylelint-no-unresolved-module:
-        specifier: ^2.4.0
+        specifier: ^2.5.0
         version: 2.5.2(stylelint@17.4.0(typescript@5.9.3))
       stylelint-no-unsupported-browser-features:
         specifier: ^8.0.4
@@ -2659,8 +2662,8 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -6548,7 +6551,7 @@ snapshots:
 
   lodash.upperfirst@4.3.1: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -6994,7 +6997,7 @@ snapshots:
   scss-parser@1.0.6:
     dependencies:
       invariant: 2.2.4
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
## What

Adds a `pnpm.overrides` entry to force `lodash@4.17.23` across the monorepo, resolving [GHSA-xxjr-mmjv-4gpg](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg) (Moderate — Prototype Pollution in `_.unset` and `_.omit`).

Also bumps `stylelint-no-unresolved-module` dep range from `^2.4.0` to `^2.5.0` to match what's installed.

## Why

`stylelint-no-unresolved-module@2.5.2` depends on `scss-parser@1.0.6`, which pins `lodash@4.17.21` exactly. The patched version is `4.17.23`. Since `scss-parser` uses an exact pin, only a pnpm override can force the update.

## Context

Both `stylelint-no-indistinguishable-colors` and `stylelint-no-unresolved-module` were investigated as potential replacements due to missing stylelint 17 peer dep declarations. Both confirmed working with v17 — the peer dep range is a documentation gap, not a functional issue. Both are actively maintained. No replacements needed.

## Verification

```
$ pnpm -r why lodash
lodash@4.17.23   ← was 4.17.21
└─┬ scss-parser@1.0.6
  └─┬ stylelint-no-unresolved-module@2.5.2
    └── @benhigham/stylelint-config@0.3.0

$ pnpm audit
3 vulnerabilities found (all minimatch/high — upstream in eslint-plugin-sonarjs, unresolvable)
# lodash CVE: gone ✅
```