### PR TITLE
docs: configure agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,25 @@
 
 This file provides guidance to AI agents when working with code in this repository. `CLAUDE.md` is a symlink to this file.
 
-Project-scoped agent skills live in `.agents/skills/`. `.claude/skills` is a symlink to that directory.
-
 ## Overview
 
 Monorepo of shareable JavaScript/TypeScript tooling configurations published to npm under the `@benhigham` scope. Packages: eslint-config, prettier-config, stylelint-config, commitlint-config, tsconfig, browserslist-config.
+
+## Agent skills
+
+Project-scoped agent skills live in `.agents/skills/`. `.claude/skills` is a symlink to that directory.
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues for `benhigham/javascript` using the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses `status:*` labels for active workflow states and `wontfix` for rejected work. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain-doc layout. See `docs/agents/domain.md`.
 
 ## Commands
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,37 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo uses a **single-context** layout: one root `CONTEXT.md` for domain language and one root `docs/adr/` directory for architectural decisions.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-example-decision.md
+└── packages/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -2,8 +2,6 @@
 
 How the engineering skills should consume this repo's domain documentation when exploring the codebase.
 
-This repo uses a **single-context** layout: one root `CONTEXT.md` for domain language and one root `docs/adr/` directory for architectural decisions.
-
 ## Before exploring, read these
 
 - **`CONTEXT.md`** at the repo root.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `benhigham/javascript`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker     | Meaning                                  |
+| -------------------------- | ------------------------ | ---------------------------------------- |
+| `needs-triage`             | `status:needs-triage`    | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `status:needs-info`      | Waiting on reporter for more information |
+| `ready-for-agent`          | `status:ready-for-agent` | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `status:ready-for-human` | Requires human implementation            |
+| `wontfix`                  | `wontfix`                | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,14 +2,12 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker     | Meaning                                  |
-| -------------------------- | ------------------------ | ---------------------------------------- |
-| `needs-triage`             | `status:needs-triage`    | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `status:needs-info`      | Waiting on reporter for more information |
-| `ready-for-agent`          | `status:ready-for-agent` | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `status:ready-for-human` | Requires human implementation            |
-| `wontfix`                  | `wontfix`                | Will not be actioned                     |
+| Label in skills   | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
-
-Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "packageManager": "pnpm@11.3.0",
   "scripts": {
+    "prepare": "lefthook install || echo 'lefthook install failed'",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "turbo run lint",
@@ -20,7 +21,6 @@
     "lint:md": "markdownlint-cli2 \"**/*.md\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
     "lint:actions": "actionlint",
-    "prepare": "lefthook install || echo 'lefthook install failed'",
     "changeset": "changeset",
     "changeset:status": "changeset status",
     "release": "changeset publish",


### PR DESCRIPTION
## Summary
- add repo-specific agent skill conventions for issue tracking, triage labels, and domain docs
- document GitHub Issues as the tracker and status-prefixed triage labels
- move the agent skills section after the repo overview in AGENTS.md

## Validation
- pnpm run lint:md