### PR TITLE
chore(eslint-config): drop eslint-find-rules, align eslint with catalog, refresh docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,13 @@ Renovate uses default semantic commit types (`chore(deps):` for dependency updat
 
 Uses **ESLint flat config** format (ESLint 10+). Configs compose as arrays via layered entry points:
 
-- **`index.js`** (base JS) — xo + import + base plugins + prettier
-- **`typescript.js`** — base + xo-typescript + TS import/jsdoc variants; relaxes strict type rules for `.js` files
+- **`index.js`** (base JS) — `base.js` (`@eslint/js` recommended + `typescript-eslint` recommended/stylistic + curated rules + bundled plugin configs) + import + prettier
+- **`typescript.js`** — base + `typescript-eslint` `*TypeCheckedOnly` presets (scoped to TS files, see below) + `projectService` + curated type-aware rules + prettier
 - **`browser.js`** — typescript + compat plugin + testing-library (DOM) + browser globals
-- **`react.js`** — typescript + browser + jsx-a11y + xo-react + testing-library (React)
+- **`react.js`** — typescript + browser + jsx-a11y + `@eslint-react/eslint-plugin` (`recommended-type-checked`) + testing-library (React)
 - **`next.js`** — react + next plugin
+
+The `*TypeCheckedOnly` presets ship "global" blocks that disable corresponding core ESLint rules everywhere. `typescript.js` scopes those blocks to TS files only (via `scopeToTs`), so `.js` files keep their core-rule coverage from `base.js`.
 
 Optional plugins exported separately: `plugins/graphql`, `plugins/playwright`, `plugins/tailwindcss`, `plugins/turbo`.
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -88,8 +88,7 @@
     "eslint": ">=10.0.0"
   },
   "devDependencies": {
-    "eslint": "10.4.0",
-    "eslint-find-rules": "5.0.0"
+    "eslint": "10.4.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -88,7 +88,7 @@
     "eslint": ">=10.0.0"
   },
   "devDependencies": {
-    "eslint": "10.4.0"
+    "eslint": "catalog:"
   },
   "scripts": {
     "lint": "eslint .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,7 +200,7 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
     devDependencies:
       eslint:
-        specifier: 10.4.0
+        specifier: 'catalog:'
         version: 10.4.0(jiti@2.7.0)
 
   packages/prettier-config:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,9 +202,6 @@ importers:
       eslint:
         specifier: 10.4.0
         version: 10.4.0(jiti@2.7.0)
-      eslint-find-rules:
-        specifier: 5.0.0
-        version: 5.0.0(eslint@10.4.0(jiti@2.7.0))
 
   packages/prettier-config:
     dependencies:
@@ -1545,9 +1542,6 @@ packages:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
 
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -1857,13 +1851,6 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-find-rules@5.0.0:
-    resolution: {integrity: sha512-k35gAhqfOBVbvFdMahYuK/jaoa5tVRH8lYZyQbAuySUTXmLsNpOkLeUpZzbZD+LplspIBWeu/G847YeFP1a6Zw==}
-    engines: {node: ^18.20 || ^20.18 || ^22.13 || >= 23.6}
-    hasBin: true
-    peerDependencies:
-      eslint: ^8.57.1 || ^9.18.0
-
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2048,10 +2035,6 @@ packages:
     peerDependencies:
       eslint: '>=9.38.0'
 
-  eslint-rule-documentation@1.0.23:
-    resolution: {integrity: sha512-pWReu3fkohwyvztx/oQWWgld2iad25TfUdi6wvhhaDPIQjHU/pyvlKgXFw1kX31SQK2Nq9MH+vRDWB0ZLy8fYw==}
-    engines: {node: '>=4.0.0'}
-
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2191,9 +2174,6 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2254,10 +2234,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
@@ -2426,10 +2402,6 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3143,10 +3115,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -3862,11 +3830,6 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  window-size@0.3.0:
-    resolution: {integrity: sha512-aB2BGVMsX1iPJ79hqC5JvbDvUXpy3nhoxmbiFw74aEewrHPnkNiFYAFbx+BgurhxuOUZV+qIj/9HurtO8ZTH5w==}
-    engines: {node: '>= 0.10.0'}
-    hasBin: true
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -3905,10 +3868,6 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -3916,10 +3875,6 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -5384,12 +5339,6 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -5733,15 +5682,6 @@ snapshots:
     dependencies:
       eslint: 10.4.0(jiti@2.7.0)
 
-  eslint-find-rules@5.0.0(eslint@10.4.0(jiti@2.7.0)):
-    dependencies:
-      cliui: 7.0.4
-      eslint: 10.4.0(jiti@2.7.0)
-      eslint-rule-documentation: 1.0.23
-      glob: 7.2.3
-      window-size: 0.3.0
-      yargs: 16.2.0
-
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
       get-tsconfig: 4.14.0
@@ -6048,8 +5988,6 @@ snapshots:
       semver: 7.8.1
       strip-indent: 4.1.1
 
-  eslint-rule-documentation@1.0.23: {}
-
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -6216,8 +6154,6 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  fs.realpath@1.0.0: {}
-
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -6286,15 +6222,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   global-directory@5.0.0:
     dependencies:
@@ -6442,11 +6369,6 @@ snapshots:
   indent-string@5.0.0: {}
 
   index-to-position@1.2.0: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -7238,8 +7160,6 @@ snapshots:
   parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
-
-  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -8050,8 +7970,6 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
-  window-size@0.3.0: {}
-
   word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
@@ -8078,21 +7996,9 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yargs-parser@20.2.9: {}
-
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
-
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:


### PR DESCRIPTION
## Summary

- **`chore(eslint-config)`** — drop the `eslint-find-rules` devDependency. Nothing in the repo referenced it (no script, no CI step, no docs); `pnpm install` removes 10 packages from the lockfile.
- **`docs(agents)`** — the ESLint config no longer extends any `xo` presets, but `AGENTS.md` still described `index.js`/`typescript.js`/`react.js` as layering `xo`/`xo-typescript`/`xo-react`. Updated the bullets to reflect the actual layering (`@eslint/js` + `typescript-eslint` + `@eslint-react/eslint-plugin`) and added a paragraph explaining why `typescript.js` scopes the `*TypeCheckedOnly` presets to TS files only.
- **`chore(eslint-config)`** — switch the `eslint` devDependency from a pinned `10.4.0` to `catalog:`. Every other workspace package was already using `catalog:` (which resolves to `^10.0.0` in `pnpm-workspace.yaml`); this one was the outlier.

No changeset — all changes are devDep-only or doc-only, invisible to consumers.

## Test plan

- [x] `pnpm run lint` (Turbo across all 6 packages) — green
- [x] `pnpm run lint:md` — green
- [x] `pnpm run format:check` — green
- [x] Lefthook pre-commit hooks ran on all three commits — green
- [ ] CI green