### PR TITLE
refactor(eslint-config): normalize no-unsanitized plugin config

### DIFF
--- a/packages/eslint-config/src/plugins/no-unsanitized.js
+++ b/packages/eslint-config/src/plugins/no-unsanitized.js
@@ -4,13 +4,15 @@ import { DEFAULT_FILES } from '../lib/file-patterns.js';
 
 /** @import { Linter } from 'eslint' */
 
-const { plugins, rules } = eslintPluginNoUnsanitized.configs.recommended;
-
 /** @type {Linter.Config} */
 const config = {
   files: [...DEFAULT_FILES],
-  plugins,
-  rules,
+  plugins: {
+    'no-unsanitized': eslintPluginNoUnsanitized,
+  },
+  rules: {
+    ...eslintPluginNoUnsanitized.configs.recommended.rules,
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary

- Rewrite `packages/eslint-config/src/plugins/no-unsanitized.js` to match the explicit `plugins` + `rules`-spread pattern used by every other module in `src/plugins/` (compat, depend, promise, sonarjs, unicorn, etc.).
- No behavioral change: `eslint-plugin-no-unsanitized`'s `configs.recommended` ships both rules at `'error'`, and this module adds no overrides.
- Non-breaking internal refactor — no changeset needed.

Closes #58.

## Test plan

- [x] `pnpm --filter @benhigham/eslint-config lint`
- [x] `pnpm run lint` (full Turborepo run)
- [x] Spot-check that `no-unsanitized/property` fires (`element.innerHTML = userInput`)
- [x] Spot-check that `no-unsanitized/method` fires (`document.write(userInput)`)