### PR TITLE
docs(changeset): reconcile release coverage for pending bumps

### DIFF
--- a/.changeset/commitlint-v21.md
+++ b/.changeset/commitlint-v21.md
@@ -2,4 +2,4 @@
 '@benhigham/commitlint-config': major
 ---
 
-Update `@commitlint/config-conventional` and `@commitlint/format` to v21. Minimum Node version is now 22.13.0 (was 22.0.0); Node 18 and 20 are no longer supported.
+Update `@commitlint/config-conventional` and `@commitlint/format` to v21. The `@commitlint/cli` peer dependency requirement is raised to `>=21.0.0` (was `>=20.0.0`), so consumers must upgrade their commitlint CLI. Minimum Node version is now 22.13.0 (was 22.0.0); Node 18 and 20 are no longer supported.

--- a/.changeset/eslint-plugin-n-v18.md
+++ b/.changeset/eslint-plugin-n-v18.md
@@ -1,0 +1,5 @@
+---
+'@benhigham/eslint-config': patch
+---
+
+Update `eslint-plugin-n` to v18. The bundled `flat/recommended` preset no longer enables `n/no-unpublished-bin`, so that rule is no longer enforced by default. The plugin is now ESM-only and raises its own minimum ESLint to `>=8.57.1` (already satisfied by this config's `eslint >=10` peer). No new rules are added to the recommended preset, so previously-clean code will not see new lint reports.

--- a/.changeset/fuzzy-pandas-sip.md
+++ b/.changeset/fuzzy-pandas-sip.md
@@ -3,3 +3,5 @@
 ---
 
 Require TypeScript 6, update browser-oriented configs for TS 6 compatibility, and remove the redundant react-library config.
+
+Also tighten `engines.node` to `>=22.13.0` (was `>=22`) to match the floor adopted across the `@benhigham` packages.


### PR DESCRIPTION
## Summary

Audited every commit since the last release (`7ae6d9a`, 2026-03-27) across all six packages and closed three changelog-accuracy gaps so each package gets the correct version bump and a complete changelog. No bump *levels* change — the two affected packages were already at `major` — these edits make the generated changelogs accurate.

### Gaps closed

- **eslint-config** — added `.changeset/eslint-plugin-n-v18.md` (patch). `eslint-plugin-n` was bumped 17→18 (#66); it's bundled via `flat/recommended`, where v18 drops `n/no-unpublished-bin` and goes ESM-only. No existing changeset recorded it (jsdoc-v63 and unicorn-v64 each had one).
- **tsconfig** — documented the `engines.node` `>=22` → `>=22.13.0` floor bump in `fuzzy-pandas-sip.md`. Every other package recorded this sweep; tsconfig's was missing.
- **commitlint-config** — documented the breaking `@commitlint/cli` `>=20` → `>=21` peer-dependency bump in `commitlint-v21.md`.

### Resulting version bumps (verified via `changeset version` dry-run)

| Package | From | To |
|---|---|---|
| browserslist-config | 1.0.1 | 1.0.2 |
| prettier-config | 1.0.1 | 1.0.2 |
| commitlint-config | 2.0.0 | 3.0.0 |
| eslint-config | 3.0.0 | 4.0.0 |
| stylelint-config | 1.0.0 | 2.0.0 |
| tsconfig | 1.0.1 | 2.0.0 |

### Note

The `eslint-plugin-n` v18 changeset is a `patch` (consistent with the `jsdoc-v63` precedent) because no *new* rules fire on previously-clean code — v18 only *removes* an enforced rule. Happy to bump it to `minor` if preferred; it won't change eslint-config's final version (already `major`).