### PR TITLE
docs: improve agent instructions; update turborepo skill

### DIFF
--- a/.agents/skills/turborepo/SKILL.md
+++ b/.agents/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.9.16-canary.2
+  version: 2.9.17-canary.1
 ---
 
 # Turborepo Skill
@@ -740,7 +740,7 @@ import { Button } from "@repo/ui/button";
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/.agents/skills/turborepo/references/best-practices/structure.md
+++ b/.agents/skills/turborepo/references/best-practices/structure.md
@@ -95,7 +95,7 @@ Package tasks enable Turborepo to:
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -117,7 +117,7 @@ With `futureFlags.globalConfiguration`, global settings move under a `global` ke
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/.agents/skills/turborepo/references/configuration/RULE.md
+++ b/.agents/skills/turborepo/references/configuration/RULE.md
@@ -73,7 +73,7 @@ When you run `turbo run lint`, Turborepo finds all packages with a `lint` script
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "globalEnv": ["CI"],
   "globalDependencies": ["tsconfig.json"],
   "tasks": {
@@ -97,7 +97,7 @@ When the `globalConfiguration` future flag is enabled, global options move under
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/.agents/skills/turborepo/references/environment/RULE.md
+++ b/.agents/skills/turborepo/references/environment/RULE.md
@@ -107,7 +107,7 @@ When the `globalConfiguration` future flag is enabled, global environment keys m
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "NPM_TOKEN"],
   "tasks": {

--- a/.agents/skills/turborepo/references/environment/gotchas.md
+++ b/.agents/skills/turborepo/references/environment/gotchas.md
@@ -112,7 +112,7 @@ If you use `.env.development` and `.env.production`, both should be in inputs.
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV", "VERCEL"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "VERCEL_URL"],
   "tasks": {
@@ -146,7 +146,7 @@ The same config using the `global` key. The `.env` files move to `global.inputs`
 
 ```json
 {
-  "$schema": "https://v2-9-16-canary-2.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-17-canary-1.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "env": ["CI", "NODE_ENV", "VERCEL"],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,8 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "benhigham/javascript"
+      "repo": "benhigham/javascript",
+      "disableThanks": true
     }
   ],
   "commit": false,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This repo uses a single-context domain-doc layout. See `docs/agents/domain.md`.
 ```bash
 pnpm install                          # Install dependencies
 pnpm run lint                         # Lint all packages (via Turborepo)
+pnpm run lint:affected                # Lint only packages affected by changes
 pnpm run lint:fix                     # Auto-fix lint issues across all packages
 pnpm run lint:md                      # markdownlint over all *.md files
 pnpm run lint:md:fix                  # markdownlint auto-fix
@@ -53,6 +54,8 @@ Each package has `lint` and `lint:fix` scripts. Formatting is run from the repos
 
 The monorepo dogfoods its own configs: `@benhigham/prettier-config` (via `prettier.config.js`) and `@benhigham/commitlint-config` (via `commitlint.config.js`), both referenced as `workspace:*` devDependencies.
 
+Dependency pinning has release implications. Bundled plugins that ship to consumers (e.g. `@eslint-react/...`, `@graphql-eslint/...`) are direct `dependencies`, pinned with `^` in each package — bumping one is consumer-facing and **needs a changeset**. Tooling used only to develop this repo (`eslint`, `prettier`, `stylelint`, `@commitlint/cli`) routes through `catalog:` in devDependencies and warrants no release. CONTEXT.md formalizes these as _consumer-facing_ vs _tooling_ dependencies.
+
 ## Commit Convention
 
 Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) enforced by commitlint (extends `@commitlint/config-conventional`). Body lines max 100 characters.
@@ -75,7 +78,7 @@ The `*TypeCheckedOnly` presets ship "global" blocks that disable corresponding c
 
 Optional plugins exported separately: `plugins/graphql`, `plugins/playwright`, `plugins/tailwindcss`, `plugins/turbo`.
 
-Plugin configs live in `src/plugins/` and follow a consistent pattern: import plugin, define config object with files/rules/plugins, export default. File globs and extension lists are centralized in `src/constants.js`.
+Plugin configs live in `src/plugins/` and follow a consistent pattern: import plugin, define config object with files/rules/plugins, export default. File globs and extension lists are centralized in `src/lib/file-patterns.js` (browser globals in `src/lib/browser-globals.js`).
 
 ### Other Packages
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# JavaScript Tooling Configs
+
+Monorepo of shareable JavaScript/TypeScript tooling configurations published to npm under the `@benhigham` scope.
+
+## Language
+
+**Consumer-facing dependency**:
+A runtime `dependency` of a published config package that ships to and affects consumers — e.g. the bundled ESLint/Stylelint plugins, or `@commitlint/config-conventional`. A bump to one changes consumer behaviour and warrants a release. Pinned directly in each package's `package.json`.
+_Avoid_: bundled dependency (use only when contrasting against peer/dev)
+
+**Tooling dependency**:
+A dependency used only to develop, lint, or build this repo, routed through the pnpm `catalog:` (e.g. `eslint`, `typescript`, `prettier`, `stylelint`, `turbo`). A bump has no consumer impact and warrants no release.
+_Avoid_: dev dependency (overloaded with the literal `devDependencies` field)
+
+**Release coverage**:
+The invariant that every change to a published package's consumer-facing surface has a corresponding changeset, so its version bump and changelog are complete and nothing needs retroactive reconciliation.
+_Avoid_: changeset coverage

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "vercel/turborepo",
       "sourceType": "github",
       "skillPath": "skills/turborepo/SKILL.md",
-      "computedHash": "2251726f273c1b4c8cab2010c221b61c5f572524411fc5a7d2d2de88dca786c4"
+      "computedHash": "b7c3165ae67a2892d6195a5b2cba15c8d96341f5c64ddd0d3ce4225c94a2ae83"
     }
   }
 }


### PR DESCRIPTION
## Summary

Housekeeping across docs, vendored skills, and changeset config. No published-package source changes, so no changeset is required.

## Changes

- **`docs(agents)`** — Audit and fix `AGENTS.md` (symlinked as `CLAUDE.md`):
  - Correct stale `src/constants.js` reference to `src/lib/file-patterns.js` (the actual home of file globs/extension lists; browser globals in `src/lib/browser-globals.js`).
  - Document `pnpm run lint:affected`.
  - Add the `catalog:` vs direct-dependency release rule (bundled plugins are consumer-facing and need a changeset; tooling routed through `catalog:` does not), using CONTEXT.md's vocabulary.
- **`docs`** — Add `CONTEXT.md` domain glossary (consumer-facing vs tooling dependency, release coverage).
- **`chore(skills)`** — Update vendored turborepo skill to `2.9.17-canary.1` (via `npx skills update`).
- **`chore(changeset)`** — Set `disableThanks` in the changelog config.

## Verification

- `pnpm run lint:md` — 0 errors.
- All commits passed pre-commit (Prettier, markdownlint) and commitlint hooks.