### PR TITLE
fix(stylelint-config): rename rules removed in stylelint-scss@7

### DIFF
--- a/.changeset/stylelint-scss7-rule-renames.md
+++ b/.changeset/stylelint-scss7-rule-renames.md
@@ -1,0 +1,10 @@
+---
+'@benhigham/stylelint-config': minor
+---
+
+Fix two rules that no longer exist in `stylelint-scss@7`, which were reported as `Unknown rule` on every linted file and never actually ran.
+
+- `scss/at-import-partial-extension` → `scss/load-partial-extension` (the rule was generalised from `@import`-only to all load directives; still configured as `'never'`).
+- `scss/max-nesting-depth` → core `max-nesting-depth` (the SCSS-plugin rule was removed in favour of stylelint core; still configured as `3`).
+
+**Heads up — two previously-inert checks now enforce:** because these rules were unknown, they did nothing on the published config. With the corrected names they are active, so a project may see new failures where its SCSS nests deeper than 3 levels, or carries file extensions in `@use`/`@forward`/`@import` partial paths. Resolve the reports, or override the rules locally if the stricter enforcement isn't wanted.

--- a/packages/stylelint-config/src/index.js
+++ b/packages/stylelint-config/src/index.js
@@ -18,6 +18,9 @@ const config = {
     'plugin/use-baseline': [true, { available: 'newly' }],
     'plugin/no-unsupported-browser-features': true,
 
+    // Performance
+    'plugin/no-low-performance-animation-properties': true,
+
     // SCSS-specific rules
     'scss/at-rule-no-unknown': true,
     'scss/selector-no-redundant-nesting-selector': true,
@@ -25,11 +28,11 @@ const config = {
     'scss/at-extend-no-missing-placeholder': true,
     'scss/load-partial-extension': 'never',
     'scss/at-mixin-pattern': '^[a-z][a-zA-Z0-9]+$',
-    'max-nesting-depth': 3,
 
     // Selector and class naming
     'selector-max-id': 0,
     'selector-max-specificity': '0,3,2',
+    'max-nesting-depth': 3,
 
     // General consistency
     'color-named': 'never',
@@ -84,7 +87,6 @@ const config = {
     'csstools/media-use-custom-media': 'always',
     'csstools/use-nesting': 'always',
     'gamut/color-no-out-gamut-range': true,
-    'plugin/no-low-performance-animation-properties': true,
   },
   overrides: [
     {

--- a/packages/stylelint-config/src/index.js
+++ b/packages/stylelint-config/src/index.js
@@ -23,9 +23,9 @@ const config = {
     'scss/selector-no-redundant-nesting-selector': true,
     'scss/dollar-variable-pattern': '^[a-z][a-zA-Z0-9]+$',
     'scss/at-extend-no-missing-placeholder': true,
-    'scss/at-import-partial-extension': 'never',
+    'scss/load-partial-extension': 'never',
     'scss/at-mixin-pattern': '^[a-z][a-zA-Z0-9]+$',
-    'scss/max-nesting-depth': 3,
+    'max-nesting-depth': 3,
 
     // Selector and class naming
     'selector-max-id': 0,


### PR DESCRIPTION
## Summary

Two `scss/*` rules in `@benhigham/stylelint-config` no longer exist in `stylelint-scss@7` (resolving to `7.1.1` via `stylelint-config-standard-scss@^17`). Stylelint reported them as `Unknown rule` on **every** linted file, and the intended checks never ran. This renames them to their current equivalents:

- `scss/at-import-partial-extension: 'never'` → `scss/load-partial-extension: 'never'` — the rule was generalised from `@import`-only to all load directives (`@use`/`@forward`/`@import`); `'never'` is still a valid primary option (`possible: ["always", "never"]` in the installed plugin).
- `scss/max-nesting-depth: 3` → core `max-nesting-depth: 3` — the SCSS-plugin rule was removed; the equivalent now lives in stylelint core and takes the integer primary option directly.

## Versioning

`fix:` commit, but a **minor** changeset: although it repairs a broken config, its consumer-facing effect is *new enforcement*. Both checks were inert (unknown), and with the corrected names they activate — a downstream project may newly fail where its SCSS nests deeper than 3 levels or carries extensions in load paths. The changeset body calls this out so the changelog warns consumers.

## Verification

- ✅ `pnpm --filter @benhigham/stylelint-config lint` passes.
- ✅ Linting a `.scss` file no longer emits any `Unknown rule` errors (previously 2 per file).
- ✅ `scss/load-partial-extension` enforces — fires `Unexpected extension ".scss" in @use` on an extensioned `@use`.
- ✅ `max-nesting-depth` enforces — fires `Too deep nesting, maximum 3` at depth 4.
- ✅ Prettier clean on changed files.

## Out of scope

- Secondary options for `max-nesting-depth` (`ignoreAtRules`, `ignore`) — kept as the faithful 1:1 bare-integer replacement.
- Any other rule in the config.
- Pinning `stylelint-scss` directly — it stays transitive via `stylelint-config-standard-scss`.

Closes #82

## Rule placement (follow-up commit)

A second commit reorganises the `rules` map for logical grouping — **purely positional, no behavioural change** (identical rule set and values), so no changeset:

- `max-nesting-depth` moved from `// SCSS-specific rules` (it is a core rule, not `scss/*`) to `// Selector and class naming`, beside the specificity controls it relates to.
- `plugin/no-low-performance-animation-properties` moved from `// General consistency` to a new `// Performance` group, matching the plugin taxonomy.
- `gamut/color-no-out-gamut-range` deliberately left under `// General consistency` (looser fit; not worth imposing a taxonomy).
