### PR TITLE
fix(eslint-config): resolve prefer-called-once vs prefer-called-times contradiction

### DIFF
--- a/.changeset/vitest-called-once-times-contradiction.md
+++ b/.changeset/vitest-called-once-times-contradiction.md
@@ -1,0 +1,5 @@
+---
+'@benhigham/eslint-config': patch
+---
+
+Fix a second contradictory vitest matcher pair (same class as the boolean matchers in the previous release). `prefer-called-once` (wants `toHaveBeenCalledOnce()`) and `prefer-called-times` (wants `toHaveBeenCalledTimes(1)`) are direct inverses on a single call, so enabling both left every "called once" assertion flagged by one rule or the other and made the autofix oscillate. Keep `prefer-called-times` (the explicit count form, consistent with preferring strict `toBe(true)` over `toBeTruthy()`) and turn `prefer-called-once` off; it only ever fired on the one-call case.

--- a/packages/eslint-config/src/plugins/vitest.js
+++ b/packages/eslint-config/src/plugins/vitest.js
@@ -40,8 +40,14 @@ const config = {
     'vitest/prefer-strict-boolean-matchers': 'error',
     'vitest/prefer-to-be-truthy': 'off',
     'vitest/prefer-to-be-falsy': 'off',
-    'vitest/prefer-called-once': 'error',
+    // Explicit count form (`toHaveBeenCalledTimes(1)`) over the
+    // `toHaveBeenCalledOnce()` shorthand — the same lean toward the explicit
+    // matcher as the strict boolean choice above. Direct inverse of
+    // `prefer-called-once` on a single call, so that stays off; enabling both
+    // leaves the assertion flagged by one rule or the other (neither touches
+    // counts other than one).
     'vitest/prefer-called-times': 'error',
+    'vitest/prefer-called-once': 'off',
     'vitest/prefer-called-with': 'error',
     'vitest/prefer-spy-on': 'error',
     'vitest/prefer-vi-mocked': 'error',


### PR DESCRIPTION
## What

A second contradictory vitest matcher pair, same class as the boolean matchers in #95 — found while adopting the release in `benhigham/web`.

`prefer-called-once` (wants `toHaveBeenCalledOnce()`) and `prefer-called-times` (wants `toHaveBeenCalledTimes(1)`) are **direct inverses on a single call**. With both `error`, every "called once" assertion is flagged by one rule or the other and `eslint --fix` oscillates with no satisfiable form — so a consumer can't pass lint on those assertions.

```js
expect(fn).toHaveBeenCalledTimes(1); // → prefer-called-once: use toHaveBeenCalledOnce()
expect(fn).toHaveBeenCalledOnce();   // → prefer-called-times: use toHaveBeenCalledTimes(1)
```

## Fix

Keep `prefer-called-times`, turn `prefer-called-once` off. The explicit count form (`toHaveBeenCalledTimes(1)`) is congruent with the strict boolean choice in #95 (`toBe(true)` over `toBeTruthy()`) — the same lean toward the explicit matcher over a convenience shorthand, and it stays uniform with `toHaveBeenCalledTimes(n)` for n > 1. `prefer-called-once` only ever fired on the one-call case, so nothing else is lost.

## Validation

Dogfood lint + `format:check` pass. Against `benhigham/web`: with both rules on, multi-pass `--fix` left 18 findings permanently stuck (the oscillation); with this change the autofix fully converges (0 stuck) to `toHaveBeenCalledTimes(1)`.

Patch release — strictly relaxes a rule to resolve an unsatisfiable contradiction.
