### PR TITLE
fix(eslint-config): relax destructive/high-ceremony vitest rules for app suites

### DIFF
--- a/.changeset/vitest-app-ceremony-rules.md
+++ b/.changeset/vitest-app-ceremony-rules.md
@@ -1,0 +1,11 @@
+---
+'@benhigham/eslint-config': patch
+---
+
+Relax three vitest rules that proved destructive or high-ceremony on a real app test suite (surfaced adopting the config in a static Next app).
+
+- **`prefer-called-with` (off):** its autofix rewrites `toHaveBeenCalled()` to `toHaveBeenCalledWith()` — "called with _zero_ arguments" — silently breaking every assertion on a mock that was called with arguments, and it forbids the legitimate "was it called at all" assertion on spies where the arguments aren't the point.
+- **`require-mock-type-parameters` (off):** forces a type argument on every `vi.fn()`, including mocks immediately cast to a target type (where the parameter is erased), and isn't reliably auto-fixable in practice.
+- **`prefer-expect-assertions` (off):** mandates `expect.assertions(n)` bookkeeping on async/callback/loop tests — maintenance burden that rarely catches a real bug.
+
+These only relax the curated allowlist (all three are off in `@vitest/eslint-plugin`'s `recommended`); Node-library consumers wanting the stricter set can re-enable them locally.

--- a/.changeset/vitest-app-ceremony-rules.md
+++ b/.changeset/vitest-app-ceremony-rules.md
@@ -2,10 +2,10 @@
 '@benhigham/eslint-config': patch
 ---
 
-Relax three vitest rules that proved destructive or high-ceremony on a real app test suite (surfaced adopting the config in a static Next app).
+Relax three vitest rules that proved destructive or high-ceremony on a real app test suite (surfaced while adopting the config in a static Next app).
 
 - **`prefer-called-with` (off):** its autofix rewrites `toHaveBeenCalled()` to `toHaveBeenCalledWith()` — "called with _zero_ arguments" — silently breaking every assertion on a mock that was called with arguments, and it forbids the legitimate "was it called at all" assertion on spies where the arguments aren't the point.
 - **`require-mock-type-parameters` (off):** forces a type argument on every `vi.fn()`, including mocks immediately cast to a target type (where the parameter is erased), and isn't reliably auto-fixable in practice.
-- **`prefer-expect-assertions` (off):** mandates `expect.assertions(n)` bookkeeping on async/callback/loop tests — maintenance burden that rarely catches a real bug.
+- **`prefer-expect-assertions` (off):** mandates `expect.assertions(n)` bookkeeping on async/callback/loop tests — a maintenance burden that rarely catches a real bug.
 
 These only relax the curated allowlist (all three are off in `@vitest/eslint-plugin`'s `recommended`); Node-library consumers wanting the stricter set can re-enable them locally.

--- a/packages/eslint-config/src/plugins/vitest.js
+++ b/packages/eslint-config/src/plugins/vitest.js
@@ -48,7 +48,12 @@ const config = {
     // counts other than one).
     'vitest/prefer-called-times': 'error',
     'vitest/prefer-called-once': 'off',
-    'vitest/prefer-called-with': 'error',
+    // `prefer-called-with` is off: its autofix rewrites `toHaveBeenCalled()` to
+    // `toHaveBeenCalledWith()` (i.e. "called with *zero* args"), silently
+    // breaking every assertion on a mock that was called with arguments. It
+    // also forbids the legitimate "was it called at all" assertion on spies
+    // where the arguments aren't the point.
+    'vitest/prefer-called-with': 'off',
     'vitest/prefer-spy-on': 'error',
     'vitest/prefer-vi-mocked': 'error',
     'vitest/prefer-mock-promise-shorthand': 'error',
@@ -82,19 +87,17 @@ const config = {
     'vitest/require-hook': 'error',
     'vitest/no-test-return-statement': 'error',
 
-    // Auto-fixable, so cheap to enforce.
-    'vitest/require-mock-type-parameters': 'error',
-
-    // Scope to where missing assertions hide real bugs (async/callback/loop)
-    // rather than mandating `expect.assertions()` in every test.
-    'vitest/prefer-expect-assertions': [
-      'error',
-      {
-        onlyFunctionsWithAsyncKeyword: true,
-        onlyFunctionsWithExpectInCallback: true,
-        onlyFunctionsWithExpectInLoop: true,
-      },
-    ],
+    // High-ceremony rules, off for app/browser consumers: they impose broad,
+    // low-value churn on a typical app test suite for little safety. (Node
+    // libraries can re-enable them locally.)
+    // - `require-mock-type-parameters`: forces a type argument on every
+    //   `vi.fn()`, including mocks immediately cast to a target type (where the
+    //   parameter is erased); not reliably auto-fixable in practice.
+    // - `prefer-expect-assertions`: mandates `expect.assertions(n)` bookkeeping
+    //   on async/callback/loop tests — a maintenance burden that rarely catches
+    //   a real bug here.
+    'vitest/require-mock-type-parameters': 'off',
+    'vitest/prefer-expect-assertions': 'off',
   },
 };
 


### PR DESCRIPTION
## What

Three vitest rules in the curated allowlist proved destructive or high-ceremony when adopting the config in a real app test suite ([benhigham/web#229](https://github.com/benhigham/web/issues/229)). All three are **off in `@vitest/eslint-plugin`'s `recommended`** — this only relaxes the layered allowlist, so it strictly reduces what fires.

- **`prefer-called-with` → off.** Its autofix rewrites `toHaveBeenCalled()` to `toHaveBeenCalledWith()` (i.e. "called with **zero** arguments"). On a `--fix` run across `web`'s suite this silently broke every assertion on a mock that was actually called with arguments, plus it forbids the legitimate "was it called at all" assertion on spies (`rafSpy`, `cancelSpy`, observer `disconnect`s) where the arguments aren't the point.
- **`require-mock-type-parameters` → off.** Forces a type argument on every `vi.fn()` — including the ~40 in one file that are immediately cast `as unknown as CanvasRenderingContext2D` (parameter erased). Not reliably auto-fixable in practice, so it's pure manual ceremony.
- **`prefer-expect-assertions` → off.** Mandates `expect.assertions(n)` bookkeeping on async/callback/loop tests — a maintenance burden that rarely catches a real bug here.

## Validation

Dogfood lint + `format:check` pass. Against `benhigham/web`, these three accounted for **188 findings** (and `prefer-called-with`'s autofix for ~14 broken tests); turning them off drops `web`'s remaining lint from 429 → 241, all of which are genuinely conformable.

Patch release — relaxes rules / removes a destructive autofix; nothing gets stricter. Node-library consumers wanting the strict set can re-enable locally.

## Context

Third follow-up to ADR-0002 after #95 (app/browser adoption) and #97 (called-once/times contradiction). Same theme: the curated vitest set carried rules that are wrong or high-cost for app/browser consumers.
