### PR TITLE
fix(eslint-config): stop jsdoc corruption and honor the _-unused convention

### DIFF
--- a/.changeset/eslint-config-jsdoc-escaping-unused-vars.md
+++ b/.changeset/eslint-config-jsdoc-escaping-unused-vars.md
@@ -1,0 +1,9 @@
+---
+'@benhigham/eslint-config': minor
+---
+
+Stop corrupting JSDoc, and honor the `_`-prefix "intentionally unused" convention across JS and TS (surfaced while adopting the config in a static Next app).
+
+- **`jsdoc/text-escaping` (off, both JS and TS):** the `contents` category preset enables it at error, but every `recommended-*` bundle ships it off. Its autofix escapes `<` → `&lt;` in JSDoc, but isn't markdown-aware (it mangles `<` inside backtick code spans) and escapes only `<`, not `>` — asymmetric corruption. It targets JSDoc rendered as raw HTML; TS/TSDoc and editor hover render markdown, where the escaping is pure damage. Restores the bundle default.
+- **`no-unused-vars` honors the `_`-prefix convention across JS and TS:** `argsIgnorePattern`/`varsIgnorePattern`/`caughtErrorsIgnorePattern`/`destructuredArrayIgnorePattern` are set to `^_`, and `ignoreRestSiblings` permits the destructure-to-omit pattern (`{ a: _a, ...rest }`). Applied to TS files via `@typescript-eslint/no-unused-vars` and to JS files via core `no-unused-vars`, so a `_`-prefixed name means "intentionally unused" everywhere. `reportUsedIgnorePattern: true` keeps the convention honest: a `_`-prefixed name that is actually used is now flagged (rename it) — that option can newly-fail previously-passing code, hence the minor bump.
+- **`sonarjs/no-unused-vars` (off):** it duplicated unused detection but ignored the `_` patterns and `ignoreRestSiblings` above (it flagged the destructure-to-omit `_a`), so unused detection now defers entirely to `no-unused-vars` — matching the existing `sonarjs/unused-import: off` precedent.

--- a/packages/eslint-config/src/base.js
+++ b/packages/eslint-config/src/base.js
@@ -95,6 +95,21 @@ export const rules = {
   'prefer-spread': 'error',
 };
 
+// Shared `no-unused-vars` tuning honoring the `_`-prefix "intentionally unused"
+// convention. Applied to TS files via `@typescript-eslint/no-unused-vars` (in
+// `tsRules`) and to JS files via core `no-unused-vars` (the JS-scoped block in
+// `config`), so the convention holds in both. `ignoreRestSiblings` permits the
+// destructure-to-omit pattern (`{ a: _a, ...rest }`); `reportUsedIgnorePattern`
+// keeps it honest — a `_`-prefixed name that is actually used is flagged.
+const unusedVarsOptions = {
+  argsIgnorePattern: '^_',
+  varsIgnorePattern: '^_',
+  caughtErrorsIgnorePattern: '^_',
+  destructuredArrayIgnorePattern: '^_',
+  ignoreRestSiblings: true,
+  reportUsedIgnorePattern: true,
+};
+
 /**
  * Non-type-aware `@typescript-eslint/*` tunings. Applied to TS files only; the
  * type-aware tunings live in `./typescript.js`.
@@ -153,6 +168,7 @@ export const tsRules = {
   ],
   '@typescript-eslint/no-shadow': ['error', { ignoreOnInitialization: true }],
   '@typescript-eslint/no-this-alias': ['error', { allowDestructuring: true }],
+  '@typescript-eslint/no-unused-vars': ['error', unusedVarsOptions],
   '@typescript-eslint/triple-slash-reference': [
     'error',
     { path: 'never', types: 'never', lib: 'never' },
@@ -198,6 +214,16 @@ const config = [
   {
     files: [...TS_FILES],
     rules: tsRules,
+  },
+  // Honor the `_`-prefix convention for core `no-unused-vars` on JS files (TS
+  // files get it via `@typescript-eslint/no-unused-vars` in `tsRules`). Applied
+  // once here is enough: nothing in `index.js`/`typescript.js` re-touches core
+  // `no-unused-vars` for JS files after this base config.
+  {
+    files: [...JS_FILES],
+    rules: {
+      'no-unused-vars': ['error', unusedVarsOptions],
+    },
   },
 ];
 

--- a/packages/eslint-config/src/plugins/jsdoc.js
+++ b/packages/eslint-config/src/plugins/jsdoc.js
@@ -40,6 +40,13 @@ export const jsConfig = {
     // cross-file, or `@import`ed types as undefined.
     'jsdoc/no-types': 'off',
     'jsdoc/no-undefined-types': 'off',
+    // The `contents` category enables `text-escaping` at error; every
+    // `recommended-*` bundle ships it off. Restore that: its autofix escapes
+    // `<` -> `&lt;` in JSDoc but isn't markdown-aware (it mangles `<` inside
+    // backtick code spans) and escapes only `<`, not `>` (asymmetric garbage).
+    // It targets JSDoc rendered as raw HTML; TS/TSDoc and editor hover render
+    // markdown, so the escaping is pure corruption there.
+    'jsdoc/text-escaping': 'off',
   },
 };
 
@@ -57,5 +64,9 @@ export const tsConfig = {
     // `check-tag-names` should run in typed mode.
     'jsdoc/no-undefined-types': 'off',
     'jsdoc/check-tag-names': ['error', { typed: true }],
+    // See `jsConfig` above: the `contents` category re-enables `text-escaping`
+    // that every `recommended-*` bundle ships off; its non-markdown-aware
+    // autofix corrupts `<` inside code spans. Restore the bundle default.
+    'jsdoc/text-escaping': 'off',
   },
 };

--- a/packages/eslint-config/src/plugins/sonarjs.js
+++ b/packages/eslint-config/src/plugins/sonarjs.js
@@ -12,7 +12,12 @@ const config = {
   },
   rules: {
     ...eslintPluginSonarjs.configs.recommended.rules,
-    'sonarjs/unused-import': 'off', // We use `no-unused-vars` instead.
+    // Defer all unused detection to `no-unused-vars`, which honors the
+    // `_`-prefix convention and `ignoreRestSiblings`; sonarjs's overlapping
+    // rules ignore both (e.g. they flag the destructure-to-omit `{ a: _a,
+    // ...rest }`). `no-unused-function-argument` is already off in recommended.
+    'sonarjs/unused-import': 'off',
+    'sonarjs/no-unused-vars': 'off',
   },
 };
 


### PR DESCRIPTION
## Summary

Stops `@benhigham/eslint-config` from corrupting JSDoc, and makes the `_`-prefix "intentionally unused" convention work across JS and TS. Surfaced while adopting the config in a static Next app (`benhigham/web`).

| Rule | Change | Scope |
| --- | --- | --- |
| `jsdoc/text-escaping` | `off` | JS + TS jsdoc configs |
| `no-unused-vars` (core) | honor `^_` ignore patterns + `ignoreRestSiblings` + `reportUsedIgnorePattern` | JS files |
| `@typescript-eslint/no-unused-vars` | same options (shared object) | TS files |
| `sonarjs/no-unused-vars` | `off` | all files |

Both unused-vars entries share one `unusedVarsOptions` object in `base.js` so they can't drift.

## Why

- **`jsdoc/text-escaping` corrupts comments.** It rides in via the `contents` category preset at error, but every `recommended-*` bundle ships it `off` — composing the granular categories instead of the bundle is the only reason it's on. Its autofix escapes `<` → `&lt;` in JSDoc, but isn't markdown-aware (it mangles `<` inside backtick code spans) and escapes only `<`, not `>` — asymmetric garbage. It targets JSDoc rendered as raw HTML; TS/TSDoc and editor hover render markdown, where the escaping is pure damage. Turning it off in both jsdoc configs restores the bundle default. (It had already produced three corruptions in `web`, all inside code spans.)
- **`no-unused-vars` ignored the `_`-prefix convention.** The config inherited a bare `@typescript-eslint/no-unused-vars: error` (no options), so `_cb` (unused arg) and `{ exit: _exit, …, ...rest }` (destructure-to-omit) were flagged, each forcing an `eslint-disable`. The convention is now honored via `^_` patterns + `ignoreRestSiblings`, applied to **both** JS (core rule) and TS (the `@typescript-eslint` rule) so it holds language-wide — including this repo's own `.js` source. `reportUsedIgnorePattern: true` keeps it honest: a `_`-name that is actually *used* is flagged, so `_` can't become a lazy silencer.
- **`sonarjs/no-unused-vars` defeated the above.** It duplicated unused detection but ignored the `_` patterns and `ignoreRestSiblings` (it independently flagged the destructure-to-omit `_a`). Unused detection now defers entirely to `no-unused-vars`, matching the existing `sonarjs/unused-import: off` precedent in the same file (`sonarjs/no-unused-function-argument` is already off in recommended).

## Verification

- `pnpm lint` (self-lint, all six Turbo tasks), Prettier, and markdownlint — all clean. Self-lint stays green: zero used `_`-prefixed identifiers in published source.
- Behavioral checks against throwaway fixtures using the real config:
  - JSDoc with `` `<Foo>` `` and `a < b` survives `eslint --fix` **unescaped** (no `&lt;`).
  - Unused `_evt` arg and `{ a: _a, ...rest }` destructure **don't** error (JS and TS).
  - A **used** `_foo` (TS) / `_bar` (JS) **does** error via `reportUsedIgnorePattern` — both layers.
  - `sonarjs/no-unused-vars` no longer fires on the destructure-to-omit `_a`.

## Notes

- **Minor bump** (`.changeset/eslint-config-jsdoc-escaping-unused-vars.md`). The text-escaping and sonarjs changes are pure relaxes, but `reportUsedIgnorePattern: true` can *newly-fail* previously-passing code (a consumer with a deliberately-named used `_foo`), so this is additive strictness — same line that made #95 minor while #97/#99/#101 stayed patch.
- No `CONTEXT.md`/ADR change: these are rule tunings, not new domain vocabulary, and the architectural decision that re-enabled `text-escaping` (compose categories, not the bundle) is already documented in `src/plugins/jsdoc.js`.
- Downstream `web` follow-up (revert the three `&lt;` corruptions, drop the now-redundant `no-unused-vars` disables, bump the pin) lands as a separate PR after this releases.
