### PR TITLE
test(eslint-config): assert the resolved config per file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,14 @@ jobs:
         if: github.event_name != 'pull_request'
         run: pnpm run lint
 
+      - name: Test affected packages
+        if: github.event_name == 'pull_request'
+        run: pnpm run test:affected
+
+      - name: Test all packages
+        if: github.event_name != 'pull_request'
+        run: pnpm run test
+
       - name: Lint markdown
         run: pnpm run lint:md
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,3 +31,11 @@ _Avoid_: bundler config, noEmit config
 **Browserslist floor**:
 The lowest browser/runtime a consumer's code must not break, taken from `@benhigham/browserslist-config` (e.g. `chrome 109`). It is the line that decides whether a lint rule belongs in the browser eslint layer: a rule that steers code toward syntax or APIs newer than the floor — which `compat` does not catch (it misses ECMAScript built-ins and regex-flag syntax) — is relaxed there.
 _Avoid_: baseline, browser target, browserslist target
+
+**Resolved config**:
+The rule set (with parser, globals, and settings) ESLint computes for a single file path after composing every layer of an exported `@benhigham/eslint-config` config. It is what a consumer's file actually gets — the genuine interface of the package, and the surface its tests assert against — as opposed to the exported config arrays, which are the ingredients that compose into it.
+_Avoid_: the config (overloaded — say "config arrays" or "config source" for the ingredients), effective config
+
+**Composition invariant**:
+A guarantee about which rule configuration wins for a given file, arising from the order and scoping of the layers an `@benhigham/eslint-config` export composes rather than from any single layer — e.g. the JS-vs-TS split that keeps the type-checked global disables off `.js`, the re-applied "last-wins" curated tail, per-environment `n`/`compat` scoping on browser source vs Node files, and prettier applied last. The class of decisions the package's tests assert against the resolved config, currently load-bearing on code comments alone.
+_Avoid_: composition decision, tuning (too vague)

--- a/docs/adr/0003-eslint-config-tested-through-resolved-config.md
+++ b/docs/adr/0003-eslint-config-tested-through-resolved-config.md
@@ -1,0 +1,15 @@
+# eslint-config is tested through its resolved config
+
+`@benhigham/eslint-config` is a deep module whose interface is the _resolved config per file_ (CONTEXT.md), and it shipped with no tests — every composition invariant was enforced by a comment. We test it by resolving each exported config against representative virtual file paths with ESLint's `calculateConfigForFile` and asserting **targeted facts** (severity + the options we set) about the effective rule entries — the same surface a consumer experiences, so a test fails for the same reason a consumer would.
+
+## Considered Options
+
+- **Lint fixtures and assert reported messages.** Rejected: asserts composition invariants by proxy, couples tests to upstream message wording (the churn this repo already designs against), and needs a real tsconfig + `projectService` for type-aware rules — the exact cost the resolved-config seam avoids. Its only unique coverage ("does the rule body run") is upstream's job; and config resolution already throws on a missing plugin or unknown/stale rule name, so the valuable smoke coverage is free.
+- **Unit-test the exported `rules`/`tsRules` objects.** Rejected: tests the ingredients, not the composition (`scopeToTs`, the last-wins tail, per-environment scoping) — i.e. not the interface.
+- **Snapshot the resolved config.** Rejected: `calculateConfigForFile` returns entries with ESLint's defaults merged in, so a snapshot drifts on every plugin/typescript-eslint minor bump and encodes no intent.
+
+## Consequences
+
+- vitest is adopted as the runner (a tooling dependency via the catalog, no release), finally exercising the vitest ESLint layer this repo ships but never ran.
+- Tests pin the load-bearing composition invariants and keep churn-prone react/next/optional-plugin rule sets at resolution-smoke level.
+- This is the enabling move for the other architecture-review refactors (tsconfig matrix, layer-assembly consolidation, plugin-wrapper collapse), which become behaviour-preserving once the interface is asserted.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "lint": "turbo run lint",
     "lint:affected": "turbo run lint --affected",
     "lint:fix": "turbo run lint:fix",
+    "test": "turbo run test",
+    "test:affected": "turbo run test --affected",
     "lint:md": "markdownlint-cli2 \"**/*.md\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
     "lint:actions": "actionlint",

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,1 +1,23 @@
-export { default } from './src/index.js';
+import config from './src/index.js';
+
+/**
+ * Dogfood the package's own base config. The shipped vitest layer sets
+ * `typecheck: true` for consumers whose tests are type-aware (`./typescript` +
+ * projectService); this package's tests are plain `.js` linted by the base (no
+ * projectService), so disable it for them — the type-aware vitest rules (e.g.
+ * `vitest/valid-title`) would otherwise throw for want of type information.
+ * @type {import('eslint').Linter.Config[]}
+ */
+const eslintConfig = [
+  ...config,
+  {
+    files: ['test/**/*.js'],
+    settings: {
+      vitest: {
+        typecheck: false,
+      },
+    },
+  },
+];
+
+export default eslintConfig;

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -89,10 +89,12 @@
     "eslint": ">=10.0.0"
   },
   "devDependencies": {
-    "eslint": "catalog:"
+    "eslint": "catalog:",
+    "vitest": "catalog:"
   },
   "scripts": {
     "lint": "eslint .",
-    "lint:fix": "eslint --fix ."
+    "lint:fix": "eslint --fix .",
+    "test": "vitest run"
   }
 }

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { FIXTURES, optionsOf, resolveConfig, severityOf } from './helpers.js';
+
+describe('scopeToTs keeps the type-checked global disables off JS files', () => {
+  it('disables core no-unused-vars on TS but keeps it on JS, under ./typescript', async () => {
+    const ts = await resolveConfig('./typescript', FIXTURES.ts);
+    const js = await resolveConfig('./typescript', FIXTURES.js);
+
+    expect(severityOf(ts, 'no-unused-vars')).toBe('off');
+    expect(severityOf(js, 'no-unused-vars')).toBe('error');
+  });
+
+  it('moves the unused-vars duty to @typescript-eslint on TS, honoring the _ convention', async () => {
+    const ts = await resolveConfig('./typescript', FIXTURES.ts);
+
+    expect(severityOf(ts, '@typescript-eslint/no-unused-vars')).toBe('error');
+    expect(optionsOf(ts, '@typescript-eslint/no-unused-vars')).toMatchObject({
+      argsIgnorePattern: '^_',
+      reportUsedIgnorePattern: true,
+    });
+  });
+
+  it('honors the _ convention for core no-unused-vars on JS files', async () => {
+    const js = await resolveConfig('./typescript', FIXTURES.js);
+
+    expect(optionsOf(js, 'no-unused-vars')).toMatchObject({
+      argsIgnorePattern: '^_',
+      reportUsedIgnorePattern: true,
+    });
+  });
+});
+
+describe('type-aware rules layer in only at ./typescript and only on TS files', () => {
+  it('omits a type-aware rule from the base (.) config', async () => {
+    const base = await resolveConfig('.', FIXTURES.ts);
+
+    expect(severityOf(base, '@typescript-eslint/no-floating-promises')).toBe('absent');
+  });
+
+  it('adds it on TS but not JS under ./typescript', async () => {
+    const ts = await resolveConfig('./typescript', FIXTURES.ts);
+    const js = await resolveConfig('./typescript', FIXTURES.js);
+
+    expect(severityOf(ts, '@typescript-eslint/no-floating-promises')).toBe('error');
+    expect(severityOf(js, '@typescript-eslint/no-floating-promises')).toBe('absent');
+  });
+});
+
+describe('curated tunings win over the presets they layer on top of', () => {
+  it('keeps @typescript-eslint/array-type at array-simple over the stylistic preset', async () => {
+    const ts = await resolveConfig('./typescript', FIXTURES.ts);
+
+    expect(optionsOf(ts, '@typescript-eslint/array-type')).toStrictEqual({
+      default: 'array-simple',
+    });
+  });
+});
+
+describe('eslint-config-prettier is applied last to turn formatting rules off', () => {
+  // unicorn enables unicorn/no-nested-ternary; prettier turns it off. If the
+  // prettier tail were dropped or reordered, this would resolve back to 'error'.
+  it.each(['.', './typescript', './browser', './react', './next'])(
+    'disables a unicorn formatting rule in the %s export',
+    async (subpath) => {
+      const config = await resolveConfig(subpath, FIXTURES.ts);
+
+      expect(severityOf(config, 'unicorn/no-nested-ternary')).toBe('off');
+    },
+  );
+});

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -47,6 +47,22 @@ describe('type-aware rules layer in only at ./typescript and only on TS files', 
   });
 });
 
+describe('the shipped vitest layer composes in, scoped to test files', () => {
+  it('applies vitest rules on a test file but leaves source untouched', async () => {
+    const test = await resolveConfig('.', FIXTURES.test);
+    const source = await resolveConfig('.', FIXTURES.ts);
+
+    expect(severityOf(test, 'vitest/prefer-to-be')).toBe('error');
+    expect(severityOf(source, 'vitest/prefer-to-be')).toBe('absent');
+  });
+
+  it('ships typecheck enabled by default (the setting this package dogfoods off)', async () => {
+    const test = await resolveConfig('.', FIXTURES.test);
+
+    expect(test.settings?.vitest?.typecheck).toBe(true);
+  });
+});
+
 describe('curated tunings win over the presets they layer on top of', () => {
   it('keeps @typescript-eslint/array-type at array-simple over the stylistic preset', async () => {
     const ts = await resolveConfig('./typescript', FIXTURES.ts);

--- a/packages/eslint-config/test/environments.test.js
+++ b/packages/eslint-config/test/environments.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { FIXTURES, optionsOf, resolveConfig, severityOf } from './helpers.js';
+
+describe('the browser layer scopes Node and browser rules to the right environment', () => {
+  it('neutralizes n/prefer-global/process on browser source but keeps it on Node files', async () => {
+    const source = await resolveConfig('./browser', FIXTURES.tsx);
+    const configFile = await resolveConfig('./browser', FIXTURES.configFile);
+    const script = await resolveConfig('./browser', FIXTURES.script);
+
+    expect(severityOf(source, 'n/prefer-global/process')).toBe('off');
+    expect(severityOf(configFile, 'n/prefer-global/process')).toBe('error');
+    expect(severityOf(script, 'n/prefer-global/process')).toBe('error');
+  });
+
+  it('runs compat on browser source but not on Node files', async () => {
+    const source = await resolveConfig('./browser', FIXTURES.tsx);
+    const configFile = await resolveConfig('./browser', FIXTURES.configFile);
+
+    expect(severityOf(source, 'compat/compat')).toBe('error');
+    expect(severityOf(configFile, 'compat/compat')).toBe('absent');
+  });
+
+  it('narrows require-unicode-regexp to the u flag on browser source only', async () => {
+    const source = await resolveConfig('./browser', FIXTURES.ts);
+    const configFile = await resolveConfig('./browser', FIXTURES.configFile);
+
+    expect(optionsOf(source, 'require-unicode-regexp')).toStrictEqual({ requireFlag: 'u' });
+    expect(optionsOf(configFile, 'require-unicode-regexp')?.requireFlag).toBeUndefined();
+  });
+});

--- a/packages/eslint-config/test/helpers.js
+++ b/packages/eslint-config/test/helpers.js
@@ -1,0 +1,121 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ESLint } from 'eslint';
+
+import * as browser from '../src/browser.js';
+import * as base from '../src/index.js';
+import * as next from '../src/next.js';
+import * as graphql from '../src/plugins/graphql.js';
+import * as jsdocRequired from '../src/plugins/jsdoc-required.js';
+import * as playwright from '../src/plugins/playwright.js';
+import * as tailwindcss from '../src/plugins/tailwindcss.js';
+import * as turbo from '../src/plugins/turbo.js';
+import * as react from '../src/react.js';
+import * as typescript from '../src/typescript.js';
+
+/** Absolute path to the package root (the parent of this `test/` directory). */
+export const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Each export's module namespace, keyed by the subpath a consumer imports.
+const MODULES = {
+  '.': base,
+  './browser': browser,
+  './next': next,
+  './react': react,
+  './typescript': typescript,
+  './plugins/graphql': graphql,
+  './plugins/jsdoc-required': jsdocRequired,
+  './plugins/playwright': playwright,
+  './plugins/tailwindcss': tailwindcss,
+  './plugins/turbo': turbo,
+};
+
+/** Standalone exports: complete config arrays a consumer uses as their whole config. */
+export const STANDALONE_EXPORTS = ['.', './browser', './next', './react', './typescript'];
+
+/**
+ * Optional plugin exports: opt-in fragments a consumer spreads onto a base
+ * config and scopes themselves. Some have no `files` (global, consumer-scoped)
+ * and graphql has no default export (it ships `operationsConfig`/`schemaConfig`),
+ * so they are smoke-tested as fragments rather than resolved standalone.
+ */
+export const PLUGIN_EXPORTS = [
+  './plugins/graphql',
+  './plugins/jsdoc-required',
+  './plugins/playwright',
+  './plugins/tailwindcss',
+  './plugins/turbo',
+];
+
+/**
+ * Representative virtual file paths the configs are resolved against. None need
+ * to exist on disk — `calculateConfigForFile` only matches the path against the
+ * config globs. `configFile` and `script` hit the two distinct `NODE_FILES`
+ * patterns (a `*.config.*` file and a path under `scripts/`); `test` hits the
+ * `TEST_FILES` pattern.
+ */
+export const FIXTURES = {
+  js: 'src/a.js',
+  ts: 'src/a.ts',
+  tsx: 'src/a.tsx',
+  configFile: 'a.config.ts',
+  script: 'scripts/x.ts',
+  test: 'src/a.test.ts',
+};
+
+/**
+ * Resolve the effective config a standalone export computes for a file path —
+ * the package's genuine interface. The path is virtual; this computes config
+ * only (it does not lint), so the TypeScript `projectService` never runs.
+ * @param {string} subpath A standalone export subpath (see `STANDALONE_EXPORTS`).
+ * @param {string} relPath A file path relative to the package root.
+ * @returns {Promise<import('eslint').Linter.Config>} The resolved config.
+ */
+export const resolveConfig = async (subpath, relPath) => {
+  const config = MODULES[subpath].default;
+  const overrideConfig = Array.isArray(config) ? config : [config];
+  const eslint = new ESLint({ overrideConfigFile: true, overrideConfig, cwd: PKG_ROOT });
+
+  return eslint.calculateConfigForFile(path.join(PKG_ROOT, relPath));
+};
+
+/**
+ * Every flat-config block an export exposes, gathered across its default and
+ * named exports. Used to smoke-test plugin fragments, which vary in shape (a
+ * single object, an array, or named exports with no default).
+ * @param {string} subpath An export subpath.
+ * @returns {import('eslint').Linter.Config[]} Every flat-config object the export ships, across its default and named exports.
+ */
+export const configBlocksOf = (subpath) =>
+  Object.values(MODULES[subpath])
+    .flatMap((value) => (Array.isArray(value) ? value : [value]))
+    .filter((block) => block !== null && typeof block === 'object');
+
+const SEVERITY = ['off', 'warn', 'error'];
+
+/**
+ * The effective severity of a rule in a resolved config: `'off'`, `'warn'`,
+ * `'error'`, or `'absent'` when no layer configured it.
+ * @param {import('eslint').Linter.Config} config A resolved config.
+ * @param {string} ruleId The rule to inspect.
+ * @returns {string} The severity, or `'absent'`.
+ */
+export const severityOf = (config, ruleId) => {
+  const entry = config.rules?.[ruleId];
+
+  if (entry === undefined) {
+    return 'absent';
+  }
+
+  return SEVERITY[entry[0]] ?? String(entry[0]);
+};
+
+/**
+ * The first options object of a resolved rule entry (the element after the
+ * severity), or `undefined` when the rule is absent or carries no options.
+ * @param {import('eslint').Linter.Config} config A resolved config.
+ * @param {string} ruleId The rule to inspect.
+ * @returns {unknown} The rule's first options argument.
+ */
+export const optionsOf = (config, ruleId) => config.rules?.[ruleId]?.[1];

--- a/packages/eslint-config/test/helpers.js
+++ b/packages/eslint-config/test/helpers.js
@@ -15,7 +15,7 @@ import * as react from '../src/react.js';
 import * as typescript from '../src/typescript.js';
 
 /** Absolute path to the package root (the parent of this `test/` directory). */
-export const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 // Each export's module namespace, keyed by the subpath a consumer imports.
 const MODULES = {
@@ -30,6 +30,14 @@ const MODULES = {
   './plugins/tailwindcss': tailwindcss,
   './plugins/turbo': turbo,
 };
+
+/**
+ * Every export subpath these helpers can resolve — the keys of `MODULES`. The
+ * smoke and invariant tests only cover what is listed here, so a guard test
+ * pins this set against `package.json` `exports` to catch a newly-shipped
+ * export that nobody added (which would otherwise ship with no coverage).
+ */
+export const TESTED_EXPORTS = Object.keys(MODULES);
 
 /** Standalone exports: complete config arrays a consumer uses as their whole config. */
 export const STANDALONE_EXPORTS = ['.', './browser', './next', './react', './typescript'];

--- a/packages/eslint-config/test/resolves.test.js
+++ b/packages/eslint-config/test/resolves.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  configBlocksOf,
+  FIXTURES,
+  PLUGIN_EXPORTS,
+  resolveConfig,
+  STANDALONE_EXPORTS,
+} from './helpers.js';
+
+// Resolving every standalone export against every fixture path is the smoke
+// surface: it proves each module imports (so every bundled plugin is present)
+// and that ESLint can normalize the result for that file — which throws on a
+// missing plugin or an unknown/stale rule name. No fixture linting is needed.
+const standaloneCases = STANDALONE_EXPORTS.flatMap((subpath) =>
+  Object.entries(FIXTURES).map(([fixture, relPath]) => ({ subpath, fixture, relPath })),
+);
+
+describe('every standalone export resolves for every fixture path', () => {
+  it.each(standaloneCases)(
+    '$subpath resolves for the $fixture fixture',
+    async ({ subpath, relPath }) => {
+      const config = await resolveConfig(subpath, relPath);
+
+      expect(config.rules).toBeTypeOf('object');
+    },
+  );
+});
+
+// The plugin exports are fragments a consumer spreads onto a base and scopes,
+// not standalone configs, so resolving them in isolation is meaningless. The
+// smoke that matches what they are: the module imports (proving the bundled
+// plugin dependency resolves) and exposes a block that registers its plugin.
+describe('every optional plugin export imports as a well-formed fragment', () => {
+  it.each(PLUGIN_EXPORTS)('%s registers its plugin', (subpath) => {
+    const blocks = configBlocksOf(subpath);
+
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks.some((block) => 'plugins' in block)).toBe(true);
+  });
+});

--- a/packages/eslint-config/test/resolves.test.js
+++ b/packages/eslint-config/test/resolves.test.js
@@ -1,12 +1,31 @@
 import { describe, expect, it } from 'vitest';
 
+import pkg from '../package.json' with { type: 'json' };
 import {
   configBlocksOf,
   FIXTURES,
   PLUGIN_EXPORTS,
   resolveConfig,
   STANDALONE_EXPORTS,
+  TESTED_EXPORTS,
 } from './helpers.js';
+
+// The coverage below only reaches the exports listed in helpers.js. Guard
+// against silent drift: a new `package.json` export that nobody adds there
+// would ship with zero coverage while the suite still looks exhaustive. These
+// assertions force the tested set to track what the package actually exports,
+// and the standalone/plugin split to partition it without gaps or overlap.
+describe('the tested export set tracks package.json exports', () => {
+  it('tests exactly the subpaths package.json exports', () => {
+    expect(new Set(TESTED_EXPORTS)).toStrictEqual(new Set(Object.keys(pkg.exports)));
+  });
+
+  it('partitions every tested export into standalone or plugin', () => {
+    expect(new Set([...STANDALONE_EXPORTS, ...PLUGIN_EXPORTS])).toStrictEqual(
+      new Set(TESTED_EXPORTS),
+    );
+  });
+});
 
 // Resolving every standalone export against every fixture path is the smoke
 // surface: it proves each module imports (so every bundled plugin is present)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     typescript:
       specifier: ^6.0.0
       version: 6.0.3
+    vitest:
+      specifier: ^4.1.8
+      version: 4.1.8
 
 importers:
 
@@ -134,7 +137,7 @@ importers:
         version: 16.2.6
       '@vitest/eslint-plugin':
         specifier: ^1.3.4
-        version: 1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.4.1(jiti@2.7.0))
@@ -199,6 +202,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.4.1(jiti@2.7.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   packages/prettier-config:
     dependencies:
@@ -900,6 +906,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
 
@@ -909,6 +918,104 @@ packages:
 
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
@@ -925,6 +1032,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@turbo/darwin-64@2.9.16':
     resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
@@ -959,8 +1069,14 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1192,6 +1308,35 @@ packages:
       vitest:
         optional: true
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
     engines: {node: '>=18.0.0'}
@@ -1297,6 +1442,10 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-metadata-inferer@0.8.1:
     resolution: {integrity: sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==}
 
@@ -1391,6 +1540,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1589,6 +1742,10 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -1669,6 +1826,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1940,9 +2100,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -2035,6 +2202,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2604,6 +2776,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2639,6 +2885,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
@@ -2868,6 +3117,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2941,6 +3193,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3100,6 +3355,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3170,6 +3430,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3216,6 +3479,12 @@ packages:
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3436,6 +3705,9 @@ packages:
     resolution: {integrity: sha512-YBGpG4bWsHoPvofT6y/5iqulfXIiIErl5B0LdtHT1mGXDFTAhhRrbUpTvBgYbovr+3cKblya2WAOcpoy90XguA==}
     engines: {node: '>=16'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.2.3:
     resolution: {integrity: sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==}
     engines: {node: '>=18'}
@@ -3443,6 +3715,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3559,6 +3835,90 @@ packages:
       typescript:
         optional: true
 
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3596,6 +3956,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4577,11 +4942,64 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@oxc-project/types@0.133.0': {}
+
   '@package-json/types@0.0.12': {}
 
   '@pkgr/core@0.3.6': {}
 
   '@repeaterjs/repeater@3.0.6': {}
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
@@ -4592,6 +5010,8 @@ snapshots:
   '@sindresorhus/base62@1.0.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@turbo/darwin-64@2.9.16':
     optional: true
@@ -4616,9 +5036,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -4809,7 +5236,7 @@ snapshots:
     dependencies:
       valibot: 1.4.1(typescript@6.0.3)
 
-  '@vitest/eslint-plugin@1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@vitest/eslint-plugin@1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.0
       '@typescript-eslint/utils': 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
@@ -4817,8 +5244,50 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       typescript: 6.0.3
+      vitest: 4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
@@ -4933,6 +5402,8 @@ snapshots:
 
   arrify@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-metadata-inferer@0.8.1:
     dependencies:
       '@mdn/browser-compat-data': 5.7.6
@@ -5018,6 +5489,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5199,6 +5672,8 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
+  detect-libc@2.1.2: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -5331,6 +5806,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -5742,7 +6219,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
 
@@ -5841,6 +6324,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -6358,6 +6844,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.1:
@@ -6387,6 +6922,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-it@14.1.1:
     dependencies:
@@ -6707,6 +7246,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -6788,6 +7329,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -6921,6 +7464,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -7014,6 +7578,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
@@ -7049,6 +7615,10 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stable-hash-x@0.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7306,12 +7876,16 @@ snapshots:
 
   timeout-signal@2.0.0: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.2.3: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7468,6 +8042,45 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.3
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
@@ -7527,6 +8140,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,4 @@ catalog:
   stylelint: ^17.4.0
   turbo: ^2.8.17
   typescript: ^6.0.0
+  vitest: ^4.1.8

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,10 @@
     },
     "lint:fix": {
       "cache": false
+    },
+    "test": {
+      "dependsOn": ["transit"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
Closes #105.

`@benhigham/eslint-config` was a deep module with no test surface — every load-bearing composition decision was enforced by a comment, invisible until a consumer tripped it. This adds tests **through the genuine interface**: resolve each exported config against representative virtual file paths with ESLint's `calculateConfigForFile` and assert targeted facts about the effective rule entries. (Design grilled in #105; rationale recorded in [ADR-0003](docs/adr/0003-eslint-config-tested-through-resolved-config.md).)

## What's tested

- **Resolution smoke** — every standalone export resolves for all 6 fixture paths (proves all bundled plugins import and every configured rule name is valid per file type, since normalization throws otherwise). Optional plugin exports are smoke-tested as fragments (graphql has no default export; `playwright`/`turbo` are `files`-less globals).
- **`scopeToTs` split + layering + the `_` convention** — core `no-unused-vars` on JS / `@typescript-eslint` on TS, and type-aware rules present only under `./typescript` and only on TS files.
- **Per-environment scoping** — `n`/`compat`/`require-unicode-regexp` on browser source vs `NODE_FILES`.
- **Last-wins tunings + prettier-off** — curated rules win over the presets they layer on; `eslint-config-prettier` disables formatting rules.

Assertions read **targeted facts** (severity + only the options we set), not snapshots — resolved entries carry upstream-merged defaults that would drift on every plugin bump.

## Wiring

- `vitest` via the `catalog:` (a **tooling dependency** — no consumer-facing surface change, so **no changeset**), with a package `test` script.
- Turbo `test` task, root `test`/`test:affected`, and CI test steps (affected-on-PR / all-on-push). Only `@benhigham/eslint-config` defines `test`, so Turbo runs it there and skips the rest.

## Notes

- The package dogfoods its base config, so the test files are linted by the shipped rules. `test/**/*.js` disables the vitest `typecheck` setting locally to dodge a latent crash in the shipped config — filed as **#110** (consumer-facing, its own changeset).
- Docs: `CONTEXT.md` gains the **Resolved config** and **Composition invariant** terms.

## Verification

`format:check` · `turbo run lint` (6 pkgs) · `turbo run test` (49 tests) · `lint:md` · `actionlint` — all green.