### PR TITLE
fix(eslint-config): scope vitest typecheck to type-aware test files

### DIFF
--- a/.changeset/eslint-config-vitest-typecheck-type-aware.md
+++ b/.changeset/eslint-config-vitest-typecheck-type-aware.md
@@ -1,0 +1,9 @@
+---
+'@benhigham/eslint-config': patch
+---
+
+Scope the vitest `typecheck` setting to type-aware test files, fixing a hard ESLint crash on non-type-aware test files (surfaced while adding the resolved-config test surface).
+
+The vitest layer set `settings.vitest.typecheck: true` in the base config, so it applied under every export and on every test file. That setting makes the type-requiring vitest rules (e.g. `vitest/valid-title`) call `getParserServices()`, which **throws** (ESLint exit 2, aborting the whole run) on any file linted without type information — i.e. a JS test file anywhere, or a TS test file under the non-type-aware base (`.`) export, neither of which sets `parserOptions.projectService`.
+
+The fix relocates `typecheck: true` out of the base vitest layer into the type-aware TypeScript layer, scoped to TS test files (new `TS_TEST_FILES` glob) and co-located with `projectService` — so the setting can only ever land where type information exists. Type-aware consumers (`./typescript`, `./browser`, `./react`, `./next`) keep the feature on their TS tests unchanged; JS test files and the base `.` export no longer crash.

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,23 +1,2 @@
-import config from './src/index.js';
-
-/**
- * Dogfood the package's own base config. The shipped vitest layer sets
- * `typecheck: true` for consumers whose tests are type-aware (`./typescript` +
- * projectService); this package's tests are plain `.js` linted by the base (no
- * projectService), so disable it for them — the type-aware vitest rules (e.g.
- * `vitest/valid-title`) would otherwise throw for want of type information.
- * @type {import('eslint').Linter.Config[]}
- */
-const eslintConfig = [
-  ...config,
-  {
-    files: ['test/**/*.js'],
-    settings: {
-      vitest: {
-        typecheck: false,
-      },
-    },
-  },
-];
-
-export default eslintConfig;
+// Dogfood the package's own base config on this repo's own sources.
+export { default } from './src/index.js';

--- a/packages/eslint-config/src/lib/file-patterns.js
+++ b/packages/eslint-config/src/lib/file-patterns.js
@@ -7,15 +7,13 @@ export const TS_FILES = ['**/*.{ts,tsx,mts,cts}'];
 export const DEFAULT_FILES = ['**/*.?(c|m)[jt]s?(x)'];
 export const GQL_FILES = ['**/*.{graphql,gql}'];
 export const TEST_FILES = ['**/__tests__/**/*.?(c|m)[jt]s?(x)', '**/*.{test,spec}.?(c|m)[jt]s?(x)'];
-// The TypeScript subset of TEST_FILES — TEST_FILES narrowed to the exact TS
-// extensions enumerated in TS_FILES, so it is a strict subset of both (the
-// extglob `?(c|m)ts?(x)` would over-match `.ctsx`/`.mtsx`, which TS_FILES omits).
-// The vitest `typecheck` setting (which makes type-aware vitest rules consult
-// parser type services) must ride only where type information exists — i.e. TS
-// test files in the type-aware layer, alongside `projectService`. Scoping the
-// setting to these globs keeps it off JS test files and off non-type-aware
-// exports, where those rules would otherwise throw a hard crash for want of type
-// info.
+// The TypeScript subset of TEST_FILES, listing the same extensions as TS_FILES
+// so it stays a strict subset of it. The vitest `typecheck` setting (which makes
+// type-aware vitest rules consult parser type services) must ride only where
+// type information exists — i.e. TS test files in the type-aware layer, alongside
+// `projectService`. Scoping the setting to these globs keeps it off JS test files
+// and off non-type-aware exports, where those rules would otherwise throw a hard
+// crash for want of type info.
 export const TS_TEST_FILES = [
   '**/__tests__/**/*.{ts,tsx,mts,cts}',
   '**/*.{test,spec}.{ts,tsx,mts,cts}',

--- a/packages/eslint-config/src/lib/file-patterns.js
+++ b/packages/eslint-config/src/lib/file-patterns.js
@@ -7,13 +7,19 @@ export const TS_FILES = ['**/*.{ts,tsx,mts,cts}'];
 export const DEFAULT_FILES = ['**/*.?(c|m)[jt]s?(x)'];
 export const GQL_FILES = ['**/*.{graphql,gql}'];
 export const TEST_FILES = ['**/__tests__/**/*.?(c|m)[jt]s?(x)', '**/*.{test,spec}.?(c|m)[jt]s?(x)'];
-// The TypeScript subset of TEST_FILES. The vitest `typecheck` setting (which
-// makes type-aware vitest rules consult parser type services) must ride only
-// where type information exists — i.e. TS test files in the type-aware layer,
-// alongside `projectService`. Scoping the setting to these globs keeps it off JS
-// test files and off non-type-aware exports, where those rules would otherwise
-// throw a hard crash for want of type info.
-export const TS_TEST_FILES = ['**/__tests__/**/*.?(c|m)ts?(x)', '**/*.{test,spec}.?(c|m)ts?(x)'];
+// The TypeScript subset of TEST_FILES — TEST_FILES narrowed to the exact TS
+// extensions enumerated in TS_FILES, so it is a strict subset of both (the
+// extglob `?(c|m)ts?(x)` would over-match `.ctsx`/`.mtsx`, which TS_FILES omits).
+// The vitest `typecheck` setting (which makes type-aware vitest rules consult
+// parser type services) must ride only where type information exists — i.e. TS
+// test files in the type-aware layer, alongside `projectService`. Scoping the
+// setting to these globs keeps it off JS test files and off non-type-aware
+// exports, where those rules would otherwise throw a hard crash for want of type
+// info.
+export const TS_TEST_FILES = [
+  '**/__tests__/**/*.{ts,tsx,mts,cts}',
+  '**/*.{test,spec}.{ts,tsx,mts,cts}',
+];
 // Node-environment files within an otherwise browser/app project — config files
 // and build scripts. In the browser/`next` layer these keep their Node rules
 // (`n`) while browser source has them neutralized; `compat` is the inverse.

--- a/packages/eslint-config/src/lib/file-patterns.js
+++ b/packages/eslint-config/src/lib/file-patterns.js
@@ -7,6 +7,13 @@ export const TS_FILES = ['**/*.{ts,tsx,mts,cts}'];
 export const DEFAULT_FILES = ['**/*.?(c|m)[jt]s?(x)'];
 export const GQL_FILES = ['**/*.{graphql,gql}'];
 export const TEST_FILES = ['**/__tests__/**/*.?(c|m)[jt]s?(x)', '**/*.{test,spec}.?(c|m)[jt]s?(x)'];
+// The TypeScript subset of TEST_FILES. The vitest `typecheck` setting (which
+// makes type-aware vitest rules consult parser type services) must ride only
+// where type information exists — i.e. TS test files in the type-aware layer,
+// alongside `projectService`. Scoping the setting to these globs keeps it off JS
+// test files and off non-type-aware exports, where those rules would otherwise
+// throw a hard crash for want of type info.
+export const TS_TEST_FILES = ['**/__tests__/**/*.?(c|m)ts?(x)', '**/*.{test,spec}.?(c|m)ts?(x)'];
 // Node-environment files within an otherwise browser/app project — config files
 // and build scripts. In the browser/`next` layer these keep their Node rules
 // (`n`) while browser source has them neutralized; `compat` is the inverse.

--- a/packages/eslint-config/src/plugins/vitest.js
+++ b/packages/eslint-config/src/plugins/vitest.js
@@ -1,6 +1,6 @@
 import eslintPluginVitest from '@vitest/eslint-plugin';
 
-import { TEST_FILES } from '../lib/file-patterns.js';
+import { TEST_FILES, TS_TEST_FILES } from '../lib/file-patterns.js';
 
 /** @import { Linter } from 'eslint' */
 
@@ -9,11 +9,6 @@ const config = {
   files: [...TEST_FILES],
   plugins: {
     vitest: eslintPluginVitest,
-  },
-  settings: {
-    vitest: {
-      typecheck: true,
-    },
   },
   languageOptions: {
     globals: {
@@ -105,6 +100,26 @@ const config = {
     // (`toBe(undefined)`, `mockReturnValue(undefined)`). The `unicorn` plugin is
     // already registered for these files by `unicorn.js`.
     'unicorn/no-useless-undefined': 'off',
+  },
+};
+
+/**
+ * The type-aware half of the vitest layer: `typecheck: true` makes the
+ * type-requiring vitest rules (e.g. `vitest/valid-title`) recognize
+ * `expectTypeOf`/`assertType` and consult the parser's type services. Those
+ * services only exist where `parserOptions.projectService` is set, so this is
+ * composed in by `typescript.js` (which owns `projectService`) and scoped to TS
+ * test files. Keeping it out of the default `config` above is deliberate: on a
+ * non-type-aware export (`.`), or a JS test file anywhere, the setting would
+ * make those rules throw a hard ESLint crash for want of type information.
+ * @type {Linter.Config}
+ */
+export const tsConfig = {
+  files: [...TS_TEST_FILES],
+  settings: {
+    vitest: {
+      typecheck: true,
+    },
   },
 };
 

--- a/packages/eslint-config/src/typescript.js
+++ b/packages/eslint-config/src/typescript.js
@@ -4,6 +4,7 @@ import tseslint from 'typescript-eslint';
 import baseConfig, { rules, tsRules } from './base.js';
 import { TS_FILES } from './lib/file-patterns.js';
 import { tsConfig as importConfig } from './plugins/import.js';
+import { tsConfig as vitestTsConfig } from './plugins/vitest.js';
 
 /** @import { Linter } from 'eslint' */
 
@@ -90,6 +91,11 @@ const config = [
       },
     },
   },
+  // Enable the vitest `typecheck` setting here, co-located with `projectService`
+  // and scoped to TS test files — the only place type information is guaranteed,
+  // so the type-requiring vitest rules never crash for want of it. The base
+  // vitest layer (in `base.js`) ships the rules; this adds the type-aware setting.
+  vitestTsConfig,
   // Re-apply curated rules after intermediate configs so our tunings win.
   { rules },
   { files: [...TS_FILES], rules: { ...tsRules, ...tsCheckedRules } },

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -56,10 +56,37 @@ describe('the shipped vitest layer composes in, scoped to test files', () => {
     expect(severityOf(source, 'vitest/prefer-to-be')).toBe('absent');
   });
 
-  it('ships typecheck enabled by default (the setting this package dogfoods off)', async () => {
-    const test = await resolveConfig('.', FIXTURES.test);
+  it('keeps the non-type-aware vitest rules on JS test files', async () => {
+    const testJs = await resolveConfig('.', FIXTURES.testJs);
 
-    expect(test.settings?.vitest?.typecheck).toBe(true);
+    expect(severityOf(testJs, 'vitest/prefer-to-be')).toBe('error');
+  });
+});
+
+describe('vitest typecheck rides with projectService — TS test files only', () => {
+  // The setting makes type-aware vitest rules (e.g. vitest/valid-title) consult
+  // parser type services, which only exist where projectService is set. It must
+  // never land on a file without type info, or those rules throw a hard crash.
+  it('omits typecheck under the non-type-aware base (.) export, on TS and JS tests', async () => {
+    const ts = await resolveConfig('.', FIXTURES.test);
+    const js = await resolveConfig('.', FIXTURES.testJs);
+
+    expect(ts.settings?.vitest?.typecheck).toBeUndefined();
+    expect(js.settings?.vitest?.typecheck).toBeUndefined();
+  });
+
+  it('enables typecheck on TS test files but not JS ones under ./typescript', async () => {
+    const ts = await resolveConfig('./typescript', FIXTURES.test);
+    const js = await resolveConfig('./typescript', FIXTURES.testJs);
+
+    expect(ts.settings?.vitest?.typecheck).toBe(true);
+    expect(js.settings?.vitest?.typecheck).toBeUndefined();
+  });
+
+  it('propagates to exports that layer on ./typescript (e.g. ./browser)', async () => {
+    const ts = await resolveConfig('./browser', FIXTURES.test);
+
+    expect(ts.settings?.vitest?.typecheck).toBe(true);
   });
 });
 

--- a/packages/eslint-config/test/helpers.js
+++ b/packages/eslint-config/test/helpers.js
@@ -60,8 +60,9 @@ export const PLUGIN_EXPORTS = [
  * Representative virtual file paths the configs are resolved against. None need
  * to exist on disk — `calculateConfigForFile` only matches the path against the
  * config globs. `configFile` and `script` hit the two distinct `NODE_FILES`
- * patterns (a `*.config.*` file and a path under `scripts/`); `test` hits the
- * `TEST_FILES` pattern.
+ * patterns (a `*.config.*` file and a path under `scripts/`); `test` and
+ * `testJs` hit the `TEST_FILES` pattern (a TS and a JS test file — the pair that
+ * pins the vitest `typecheck` setting to TS test files only).
  */
 export const FIXTURES = {
   js: 'src/a.js',
@@ -70,6 +71,7 @@ export const FIXTURES = {
   configFile: 'a.config.ts',
   script: 'scripts/x.ts',
   test: 'src/a.test.ts',
+  testJs: 'src/a.test.js',
 };
 
 /**


### PR DESCRIPTION
Closes #110.

## Problem

`src/plugins/vitest.js` set `settings.vitest.typecheck: true` in the **base** layer, so it applied under every export and on every test file. That setting makes the type-requiring vitest rules (e.g. `vitest/valid-title`) call `getParserServices()`, which **throws a hard ESLint crash** (exit 2, aborting the whole run) on any file linted without type information:

- a JS test file under any export, and
- a **TS** test file under the non-type-aware base (`.`) export

— neither of which sets `parserOptions.projectService`. The real fault axis is `projectService` present vs. absent, not JS vs. TS.

## Fix

Relocate `typecheck: true` out of the base vitest layer into the type-aware TypeScript layer, scoped to TS test files and co-located with `projectService`:

- **`file-patterns.js`** — new `TS_TEST_FILES` glob (the TS subset of `TEST_FILES`).
- **`vitest.js`** — drop `settings` from the default config; add a named `tsConfig` export holding `typecheck: true`, scoped to `TS_TEST_FILES`.
- **`typescript.js`** — compose `vitestTsConfig` right after the `projectService` block.
- **`eslint.config.js`** — remove the now-dead #105 dogfood workaround (collapses to a re-export).

Because `TS_TEST_FILES ⊂ TS_FILES` and both `vitestTsConfig` and `projectService` live in `typescript.js`, the setting can never land on a file without type info — the crash is impossible by construction. Type-aware consumers (`./typescript`, `./browser`, `./react`, `./next`) keep the feature on their TS tests unchanged; JS test files and the base `.` export no longer crash.

## Tests

- `test/helpers.js` — added `FIXTURES.testJs` (`src/a.test.js`).
- `test/composition.test.js` — replaced the bug-asserting test with the 2×2 matrix (`.`/`./typescript` × `.ts`/`.js` test), a `./browser` inheritance spot-check, and a guard that JS test files keep the non-type-aware vitest rules.

Verified: `vitest run` 61/61 pass; `eslint .` clean; real-lint smoke shows `fatalErrorCount: 0` on JS-test-under-`.`, TS-test-under-`.`, and TS-test-under-`./typescript` (with a real tsconfig, `typecheck` active and `valid-title` consulting types without throwing).

## Release

`@benhigham/eslint-config`: **patch** (changeset included) — a crash fix; type-aware consumers' behavior is preserved.

## Follow-up

#113 tracks the separate gap that `*.test-d.ts` type-test files aren't matched by `TEST_FILES` at all — deliberately kept out of this PR to keep it a behaviour-preserving patch.