### PR TITLE
feat(eslint-config): lint vitest type-test files in the type-aware layer

### DIFF
--- a/.changeset/eslint-config-type-test-files.md
+++ b/.changeset/eslint-config-type-test-files.md
@@ -1,0 +1,13 @@
+---
+'@benhigham/eslint-config': minor
+---
+
+Lint vitest type-test files (`*.test-d.ts`) in the type-aware layer.
+
+The vitest layer's `TEST_FILES` globs match `*.{test,spec}.*` and `**/__tests__/**`, but not vitest's `-d` type-test convention — so `*.test-d.ts` files (the home of `expectTypeOf`/`assertType`) never reached the vitest layer, even though `settings.vitest.typecheck: true` exists precisely to make the vitest rules type-test-aware.
+
+Type-test files are now linted, but **only under the type-aware exports** (`./typescript`, `./browser`, `./react`, `./next`): a new `TYPE_TEST_FILES` glob is governed by a dedicated block that registers the vitest plugin, applies the curated rule set, and rides with `projectService` + `typecheck: true`. This is by construction — the type-requiring vitest rules (e.g. `vitest/valid-title`) and `expect-expect`'s recognition of type assertions only work where `typecheck` and type information exist, so the base (`.`) export deliberately excludes these files (the runtime vitest layer now `ignores` them).
+
+Two curated rules are turned off for type-test files because they misfire on idiomatic type tests: `vitest/require-hook` (flags a bare top-level `expectTypeOf`/`assertType` as setup that belongs in a hook) and `vitest/padding-around-expect-groups` (treats a type assertion as a runtime expect group). Everything else in the curated set applies.
+
+This is a minor (not a patch): it adds a new file class to the linted set, so it can surface new lint errors in a consumer's CI. Builds on the `typecheck` relocation from the previous release. See ADR-0005.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,3 +39,7 @@ _Avoid_: the config (overloaded — say "config arrays" or "config source" for t
 **Composition invariant**:
 A guarantee about which rule configuration wins for a given file, arising from the order and scoping of the layers an `@benhigham/eslint-config` export composes rather than from any single layer — e.g. the JS-vs-TS split that keeps the type-checked global disables off `.js`, the re-applied "last-wins" curated tail, per-environment `n`/`compat` scoping on browser source vs Node files, and prettier applied last. The class of decisions the package's tests assert against the resolved config, currently load-bearing on code comments alone.
 _Avoid_: composition decision, tuning (too vague)
+
+**Type-test file**:
+A vitest test file using the `-d` suffix convention — `*.{test,spec}-d.{ts,tsx,mts,cts}` — whose body holds type-level assertions (`expectTypeOf`/`assertType`) rather than runtime ones. Inherently TypeScript and meaningful only with type information, so `@benhigham/eslint-config` lints it solely in the type-aware layer (where `typecheck: true` rides with `projectService`), never under the base/non-type-aware exports; the runtime test layer excludes it outright. The few curated vitest rules that assume a runtime test (`require-hook`, `padding-around-expect-groups`) are turned off for it.
+_Avoid_: type test (the activity), test file (overloaded — reserve for runtime `*.{test,spec}.*` files)

--- a/docs/adr/0005-eslint-config-type-test-files-type-aware-only.md
+++ b/docs/adr/0005-eslint-config-type-test-files-type-aware-only.md
@@ -1,0 +1,19 @@
+# Type-test files are linted only in the type-aware layer
+
+vitest type-test files (`*.{test,spec}-d.{ts,tsx,mts,cts}`, whose bodies hold `expectTypeOf`/`assertType` type-level assertions) never reached the shipped vitest layer: the runtime `TEST_FILES` globs match `*.{test,spec}.*` and `**/__tests__/**`, but not the `-d` suffix. We add a dedicated `TYPE_TEST_FILES` glob and lint these files **only** in the type-aware layer (`./typescript` and the exports that build on it), co-located with `projectService` and `settings.vitest.typecheck: true`. The base/non-type-aware vitest layer excludes type-test files outright (via `ignores`), so they are governed by exactly one block.
+
+Type-aware-only is forced by how the plugin behaves, not preference. The vitest rules only treat `expectTypeOf`/`assertType` as assertions when `typecheck` is set — without it, `expect-expect` flags every bare-`expectTypeOf` file as having no assertions — and `typecheck` in turn makes rules like `valid-title` call `getParserServices()`, which is a hard crash without type information (the very crash #114 fixed by relocating `typecheck: true` to ride with `projectService`). A type-test file is meaningful only with type information, so the base export is the wrong home: linting it there would misfire or crash.
+
+Within the type-aware block we apply the curated runtime vitest rule set minus a deny-list, established empirically rather than guessed. On idiomatic type-test files only two curated rules misfire: `require-hook` (flags a bare top-level `expectTypeOf` as setup that belongs in a hook) and `padding-around-expect-groups` (treats a type assertion as a runtime expect group). Both are turned off for type-test files. The two rules triage suspected — `consistent-test-filename` and `require-top-level-describe` — do **not** misfire: `consistent-test-filename` self-skips a `-d` file because the filename fails its `allTestPattern` gate, and `require-top-level-describe` fires only on a `test()` outside a `describe`, identically to runtime tests.
+
+## Considered Options
+
+- **Add the `-d` glob to the runtime `TEST_FILES`** (issue #113, option 1). Rejected: under the base `.` export there is no `typecheck` setting, so `expect-expect` flags every bare-`expectTypeOf` file as assertion-less and the structural rules misfire — and the file can't be type-checked there anyway.
+- **A hand-picked allow-list of type-test rules** (issue #113, option 2). Rejected: a second curation that duplicates intent and silently goes stale on plugin bumps. Reusing the curated runtime set minus a small deny-list keeps one source of truth; a newly useful type-test rule flows in automatically, and only a newly-misfiring rule needs revisiting.
+- **Accept the `__tests__/`-located overlap.** A type-test file under `__tests__/` already matches the runtime `TEST_FILES` dir glob and would keep leaking into the runtime layer (misfiring under base `.`). Rejected in favour of excluding `-d` from the runtime layer, which makes "type-aware only" literally true and yields a crisp invariant: under base `.`, a `-d` file carries no vitest rules.
+
+## Consequences
+
+- Ships as a **minor** in `@benhigham/eslint-config` and needs a changeset — it adds a new linted file class, which can surface new lint errors in a consumer's CI.
+- Asserted through the resolved config (ADR-0003): under `./typescript` a `-d` fixture resolves the vitest rules with `typecheck: true` and the two deny-listed rules `off`; under base `.` it resolves no vitest rules.
+- Builds on #114 (which relocated `typecheck: true` to ride with `projectService`); that fix must remain in place for the type-aware block to be crash-free by construction.

--- a/packages/eslint-config/src/lib/file-patterns.js
+++ b/packages/eslint-config/src/lib/file-patterns.js
@@ -18,6 +18,14 @@ export const TS_TEST_FILES = [
   '**/__tests__/**/*.{ts,tsx,mts,cts}',
   '**/*.{test,spec}.{ts,tsx,mts,cts}',
 ];
+// vitest type-test files (`expectTypeOf`/`assertType`), named with vitest's `-d`
+// suffix convention. TS-only (type tests are inherently TypeScript), listing the
+// same extensions as TS_FILES. This file class is governed solely by the
+// type-aware layer: the type-requiring vitest rules need `typecheck` +
+// `projectService`, so the runtime vitest layer excludes these (via `ignores`)
+// and `typescript.js` lints them through a dedicated block. Disjoint from
+// TEST_FILES — the `-d` suffix is unmatched by `*.{test,spec}.*`.
+export const TYPE_TEST_FILES = ['**/*.{test,spec}-d.{ts,tsx,mts,cts}'];
 // Node-environment files within an otherwise browser/app project — config files
 // and build scripts. In the browser/`next` layer these keep their Node rules
 // (`n`) while browser source has them neutralized; `compat` is the inverse.

--- a/packages/eslint-config/src/lib/file-patterns.js
+++ b/packages/eslint-config/src/lib/file-patterns.js
@@ -23,8 +23,11 @@ export const TS_TEST_FILES = [
 // same extensions as TS_FILES. This file class is governed solely by the
 // type-aware layer: the type-requiring vitest rules need `typecheck` +
 // `projectService`, so the runtime vitest layer excludes these (via `ignores`)
-// and `typescript.js` lints them through a dedicated block. Disjoint from
-// TEST_FILES — the `-d` suffix is unmatched by `*.{test,spec}.*`.
+// and `typescript.js` lints them through a dedicated block. Not a strict subset
+// of TEST_FILES: the `*.{test,spec}.*` suffix never matches a `-d` name, but the
+// `**/__tests__/**` dir glob does match a `-d` file placed under `__tests__/` —
+// the runtime layer's `ignores` covers that overlap, so a type-test file is
+// governed by the type-aware block wherever it sits.
 export const TYPE_TEST_FILES = ['**/*.{test,spec}-d.{ts,tsx,mts,cts}'];
 // Node-environment files within an otherwise browser/app project — config files
 // and build scripts. In the browser/`next` layer these keep their Node rules

--- a/packages/eslint-config/src/plugins/import.js
+++ b/packages/eslint-config/src/plugins/import.js
@@ -9,6 +9,7 @@ import {
   NODE_FILES,
   TEST_FILES,
   TEST_SUPPORT_FILES,
+  TYPE_TEST_FILES,
 } from '../lib/file-patterns.js';
 
 /** @import { Linter } from 'eslint' */
@@ -86,11 +87,13 @@ export const jsConfig = {
         // missing dependency.
         includeTypes: true,
         // Permit devDependencies in Node-environment files (config files, build
-        // scripts) and test/test-support files (helpers/mocks/fixtures/setup
-        // that import vitest, @testing-library/*, etc. but aren't named
-        // `*.{test,spec}.*`). vitest rule scoping stays on `TEST_FILES` only —
-        // this allowlist is intentionally broader.
-        devDependencies: [...NODE_FILES, ...TEST_FILES, ...TEST_SUPPORT_FILES],
+        // scripts), test/test-support files (helpers/mocks/fixtures/setup that
+        // import vitest, @testing-library/*, etc. but aren't named
+        // `*.{test,spec}.*`), and type-test files (`*.test-d.*`, which import
+        // `expectTypeOf`/`assertType` from vitest). This is the import layer, so
+        // it applies on every export — independent of the type-aware-only vitest
+        // rule scoping; the allowlist is intentionally broader.
+        devDependencies: [...NODE_FILES, ...TEST_FILES, ...TEST_SUPPORT_FILES, ...TYPE_TEST_FILES],
         optionalDependencies: false,
         peerDependencies: true,
       },

--- a/packages/eslint-config/src/plugins/vitest.js
+++ b/packages/eslint-config/src/plugins/vitest.js
@@ -99,15 +99,14 @@ const rules = {
 };
 
 /**
- * The runtime vitest layer: the curated rules on runtime test files. Type-test
- * files (`*.test-d.*`) are excluded via `ignores` — they need `typecheck` +
- * `projectService`, so they are governed solely by the type-aware
- * `tsTypeTestConfig` block (composed in `typescript.js`), never the base layer.
+ * The vitest plugin + environment globals shared by both full vitest blocks
+ * (`config` and `tsTypeTestConfig`). They differ only in `files`/`ignores`,
+ * `settings`, and `rules`; the plugin registration and globals are identical, so
+ * they live here once. (The `tsConfig` overlay below is settings-only and rides
+ * on a block that already registered these, so it does not spread this.)
  * @type {Linter.Config}
  */
-const config = {
-  files: [...TEST_FILES],
-  ignores: [...TYPE_TEST_FILES],
+const vitestEnv = {
   plugins: {
     vitest: eslintPluginVitest,
   },
@@ -116,6 +115,19 @@ const config = {
       ...eslintPluginVitest.environments.env.globals,
     },
   },
+};
+
+/**
+ * The runtime vitest layer: the curated rules on runtime test files. Type-test
+ * files (`*.test-d.*`) are excluded via `ignores` — they need `typecheck` +
+ * `projectService`, so they are governed solely by the type-aware
+ * `tsTypeTestConfig` block (composed in `typescript.js`), never the base layer.
+ * @type {Linter.Config}
+ */
+const config = {
+  ...vitestEnv,
+  files: [...TEST_FILES],
+  ignores: [...TYPE_TEST_FILES],
   rules,
 };
 
@@ -157,15 +169,8 @@ export const tsConfig = {
  * @type {Linter.Config}
  */
 export const tsTypeTestConfig = {
+  ...vitestEnv,
   files: [...TYPE_TEST_FILES],
-  plugins: {
-    vitest: eslintPluginVitest,
-  },
-  languageOptions: {
-    globals: {
-      ...eslintPluginVitest.environments.env.globals,
-    },
-  },
   settings: {
     vitest: {
       typecheck: true,

--- a/packages/eslint-config/src/plugins/vitest.js
+++ b/packages/eslint-config/src/plugins/vitest.js
@@ -1,12 +1,113 @@
 import eslintPluginVitest from '@vitest/eslint-plugin';
 
-import { TEST_FILES, TS_TEST_FILES } from '../lib/file-patterns.js';
+import { TEST_FILES, TS_TEST_FILES, TYPE_TEST_FILES } from '../lib/file-patterns.js';
 
 /** @import { Linter } from 'eslint' */
 
-/** @type {Linter.Config} */
+/**
+ * The curated vitest rule set. Shared between the runtime test layer (`config`,
+ * scoped to TEST_FILES) and the type-test layer (`tsTypeTestConfig`, scoped to
+ * TYPE_TEST_FILES), so both build on a single source of truth — the type-test
+ * block only differs by a small deny-list, applied on top.
+ * @type {Linter.RulesRecord}
+ */
+const rules = {
+  // Build up from `recommended` (the curated floor) rather than `configs.all`
+  // — `all` is a kitchen-sink that self-contradicts (e.g. `no-hooks` vs
+  // `require-hook`) and grows silently on every plugin minor bump.
+  ...eslintPluginVitest.configs.recommended.rules,
+
+  // Prefer the canonical/strict matcher over its looser equivalents.
+  'vitest/prefer-to-be': 'error',
+  'vitest/prefer-to-have-length': 'error',
+  'vitest/prefer-to-contain': 'error',
+  'vitest/prefer-comparison-matcher': 'error',
+  'vitest/prefer-equality-matcher': 'error',
+  'vitest/prefer-strict-equal': 'error',
+  // Strict boolean matcher (`toBe(true)`/`toBe(false)`) over the loose
+  // `toBeTruthy`/`toBeFalsy`. It is the direct inverse of
+  // `prefer-to-be-truthy`/`prefer-to-be-falsy`, so those stay off — enabling
+  // both leaves every boolean assertion flagged by one rule or the other.
+  'vitest/prefer-strict-boolean-matchers': 'error',
+  'vitest/prefer-to-be-truthy': 'off',
+  'vitest/prefer-to-be-falsy': 'off',
+  // Explicit count form (`toHaveBeenCalledTimes(1)`) over the
+  // `toHaveBeenCalledOnce()` shorthand — the same lean toward the explicit
+  // matcher as the strict boolean choice above. Direct inverse of
+  // `prefer-called-once` on a single call, so that stays off; enabling both
+  // leaves the assertion flagged by one rule or the other (neither touches
+  // counts other than one).
+  'vitest/prefer-called-times': 'error',
+  'vitest/prefer-called-once': 'off',
+  // `prefer-called-with` is off: its autofix rewrites `toHaveBeenCalled()` to
+  // `toHaveBeenCalledWith()` (i.e. "called with *zero* args"), silently
+  // breaking every assertion on a mock that was called with arguments. It
+  // also forbids the legitimate "was it called at all" assertion on spies
+  // where the arguments aren't the point.
+  'vitest/prefer-called-with': 'off',
+  'vitest/prefer-spy-on': 'error',
+  'vitest/prefer-vi-mocked': 'error',
+  'vitest/prefer-mock-promise-shorthand': 'error',
+  'vitest/prefer-expect-resolves': 'error',
+
+  // Consistency and aliasing.
+  'vitest/no-alias-methods': 'error',
+  'vitest/consistent-test-it': 'error',
+  'vitest/consistent-vitest-vi': 'error',
+  'vitest/no-test-prefixes': 'error',
+  'vitest/require-to-throw-message': 'error',
+
+  // Hook ordering.
+  'vitest/prefer-hooks-on-top': 'error',
+  'vitest/prefer-hooks-in-order': 'error',
+
+  // Blank-line padding around test constructs (auto-fixable).
+  'vitest/padding-around-after-all-blocks': 'error',
+  'vitest/padding-around-after-each-blocks': 'error',
+  'vitest/padding-around-before-all-blocks': 'error',
+  'vitest/padding-around-before-each-blocks': 'error',
+  'vitest/padding-around-describe-blocks': 'error',
+  'vitest/padding-around-expect-groups': 'error',
+  'vitest/padding-around-test-blocks': 'error',
+
+  // Cheap guardrails that rarely fire but catch genuine mistakes.
+  'vitest/max-nested-describe': 'error',
+  'vitest/require-top-level-describe': 'error',
+  'vitest/consistent-test-filename': 'error',
+  'vitest/no-large-snapshots': 'error',
+  'vitest/require-hook': 'error',
+  'vitest/no-test-return-statement': 'error',
+
+  // High-ceremony rules, off for app/browser consumers: they impose broad,
+  // low-value churn on a typical app test suite for little safety. (Node
+  // libraries can re-enable them locally.)
+  // - `require-mock-type-parameters`: forces a type argument on every
+  //   `vi.fn()`, including mocks immediately cast to a target type (where the
+  //   parameter is erased); not reliably auto-fixable in practice.
+  // - `prefer-expect-assertions`: mandates `expect.assertions(n)` bookkeeping
+  //   on async/callback/loop tests — a maintenance burden that rarely catches
+  //   a real bug here.
+  'vitest/require-mock-type-parameters': 'off',
+  'vitest/prefer-expect-assertions': 'off',
+
+  // Not a vitest rule, but relaxed here because it fires in test files:
+  // `unicorn/no-useless-undefined` is a destructive autofix that strips the
+  // deliberate explicit `undefined` stubs/unset values that are normal in tests
+  // (`toBe(undefined)`, `mockReturnValue(undefined)`). The `unicorn` plugin is
+  // already registered for these files by `unicorn.js`.
+  'unicorn/no-useless-undefined': 'off',
+};
+
+/**
+ * The runtime vitest layer: the curated rules on runtime test files. Type-test
+ * files (`*.test-d.*`) are excluded via `ignores` — they need `typecheck` +
+ * `projectService`, so they are governed solely by the type-aware
+ * `tsTypeTestConfig` block (composed in `typescript.js`), never the base layer.
+ * @type {Linter.Config}
+ */
 const config = {
   files: [...TEST_FILES],
+  ignores: [...TYPE_TEST_FILES],
   plugins: {
     vitest: eslintPluginVitest,
   },
@@ -15,92 +116,7 @@ const config = {
       ...eslintPluginVitest.environments.env.globals,
     },
   },
-  rules: {
-    // Build up from `recommended` (the curated floor) rather than `configs.all`
-    // — `all` is a kitchen-sink that self-contradicts (e.g. `no-hooks` vs
-    // `require-hook`) and grows silently on every plugin minor bump.
-    ...eslintPluginVitest.configs.recommended.rules,
-
-    // Prefer the canonical/strict matcher over its looser equivalents.
-    'vitest/prefer-to-be': 'error',
-    'vitest/prefer-to-have-length': 'error',
-    'vitest/prefer-to-contain': 'error',
-    'vitest/prefer-comparison-matcher': 'error',
-    'vitest/prefer-equality-matcher': 'error',
-    'vitest/prefer-strict-equal': 'error',
-    // Strict boolean matcher (`toBe(true)`/`toBe(false)`) over the loose
-    // `toBeTruthy`/`toBeFalsy`. It is the direct inverse of
-    // `prefer-to-be-truthy`/`prefer-to-be-falsy`, so those stay off — enabling
-    // both leaves every boolean assertion flagged by one rule or the other.
-    'vitest/prefer-strict-boolean-matchers': 'error',
-    'vitest/prefer-to-be-truthy': 'off',
-    'vitest/prefer-to-be-falsy': 'off',
-    // Explicit count form (`toHaveBeenCalledTimes(1)`) over the
-    // `toHaveBeenCalledOnce()` shorthand — the same lean toward the explicit
-    // matcher as the strict boolean choice above. Direct inverse of
-    // `prefer-called-once` on a single call, so that stays off; enabling both
-    // leaves the assertion flagged by one rule or the other (neither touches
-    // counts other than one).
-    'vitest/prefer-called-times': 'error',
-    'vitest/prefer-called-once': 'off',
-    // `prefer-called-with` is off: its autofix rewrites `toHaveBeenCalled()` to
-    // `toHaveBeenCalledWith()` (i.e. "called with *zero* args"), silently
-    // breaking every assertion on a mock that was called with arguments. It
-    // also forbids the legitimate "was it called at all" assertion on spies
-    // where the arguments aren't the point.
-    'vitest/prefer-called-with': 'off',
-    'vitest/prefer-spy-on': 'error',
-    'vitest/prefer-vi-mocked': 'error',
-    'vitest/prefer-mock-promise-shorthand': 'error',
-    'vitest/prefer-expect-resolves': 'error',
-
-    // Consistency and aliasing.
-    'vitest/no-alias-methods': 'error',
-    'vitest/consistent-test-it': 'error',
-    'vitest/consistent-vitest-vi': 'error',
-    'vitest/no-test-prefixes': 'error',
-    'vitest/require-to-throw-message': 'error',
-
-    // Hook ordering.
-    'vitest/prefer-hooks-on-top': 'error',
-    'vitest/prefer-hooks-in-order': 'error',
-
-    // Blank-line padding around test constructs (auto-fixable).
-    'vitest/padding-around-after-all-blocks': 'error',
-    'vitest/padding-around-after-each-blocks': 'error',
-    'vitest/padding-around-before-all-blocks': 'error',
-    'vitest/padding-around-before-each-blocks': 'error',
-    'vitest/padding-around-describe-blocks': 'error',
-    'vitest/padding-around-expect-groups': 'error',
-    'vitest/padding-around-test-blocks': 'error',
-
-    // Cheap guardrails that rarely fire but catch genuine mistakes.
-    'vitest/max-nested-describe': 'error',
-    'vitest/require-top-level-describe': 'error',
-    'vitest/consistent-test-filename': 'error',
-    'vitest/no-large-snapshots': 'error',
-    'vitest/require-hook': 'error',
-    'vitest/no-test-return-statement': 'error',
-
-    // High-ceremony rules, off for app/browser consumers: they impose broad,
-    // low-value churn on a typical app test suite for little safety. (Node
-    // libraries can re-enable them locally.)
-    // - `require-mock-type-parameters`: forces a type argument on every
-    //   `vi.fn()`, including mocks immediately cast to a target type (where the
-    //   parameter is erased); not reliably auto-fixable in practice.
-    // - `prefer-expect-assertions`: mandates `expect.assertions(n)` bookkeeping
-    //   on async/callback/loop tests — a maintenance burden that rarely catches
-    //   a real bug here.
-    'vitest/require-mock-type-parameters': 'off',
-    'vitest/prefer-expect-assertions': 'off',
-
-    // Not a vitest rule, but relaxed here because it fires in test files:
-    // `unicorn/no-useless-undefined` is a destructive autofix that strips the
-    // deliberate explicit `undefined` stubs/unset values that are normal in tests
-    // (`toBe(undefined)`, `mockReturnValue(undefined)`). The `unicorn` plugin is
-    // already registered for these files by `unicorn.js`.
-    'unicorn/no-useless-undefined': 'off',
-  },
+  rules,
 };
 
 /**
@@ -120,6 +136,45 @@ export const tsConfig = {
     vitest: {
       typecheck: true,
     },
+  },
+};
+
+/**
+ * The type-test layer: the whole vitest surface for `*.test-d.*` files. Because
+ * the runtime `config` excludes these (via `ignores`), this block must register
+ * the plugin and globals itself, then apply the curated `rules` plus
+ * `typecheck: true`. It is composed only by `typescript.js`, after the
+ * `projectService` block, so the type-requiring rules always have type info.
+ *
+ * Two curated rules are turned off here because they misfire on idiomatic type
+ * tests (empirically, against the plugin's behavior): `require-hook` flags a
+ * bare top-level `expectTypeOf`/`assertType` as setup that belongs in a hook,
+ * and `padding-around-expect-groups` treats a type assertion as a runtime expect
+ * group. The structural rules triage suspected — `consistent-test-filename`
+ * (self-skips a `-d` name via its `allTestPattern`) and `require-top-level-describe`
+ * (only fires on a `test()` outside `describe`, same as runtime) — do not, so
+ * they stay on. See ADR-0005.
+ * @type {Linter.Config}
+ */
+export const tsTypeTestConfig = {
+  files: [...TYPE_TEST_FILES],
+  plugins: {
+    vitest: eslintPluginVitest,
+  },
+  languageOptions: {
+    globals: {
+      ...eslintPluginVitest.environments.env.globals,
+    },
+  },
+  settings: {
+    vitest: {
+      typecheck: true,
+    },
+  },
+  rules: {
+    ...rules,
+    'vitest/require-hook': 'off',
+    'vitest/padding-around-expect-groups': 'off',
   },
 };
 

--- a/packages/eslint-config/src/typescript.js
+++ b/packages/eslint-config/src/typescript.js
@@ -4,7 +4,10 @@ import tseslint from 'typescript-eslint';
 import baseConfig, { rules, tsRules } from './base.js';
 import { TS_FILES } from './lib/file-patterns.js';
 import { tsConfig as importConfig } from './plugins/import.js';
-import { tsConfig as vitestTsConfig } from './plugins/vitest.js';
+import {
+  tsConfig as vitestTsConfig,
+  tsTypeTestConfig as vitestTypeTestConfig,
+} from './plugins/vitest.js';
 
 /** @import { Linter } from 'eslint' */
 
@@ -96,6 +99,11 @@ const config = [
   // so the type-requiring vitest rules never crash for want of it. The base
   // vitest layer (in `base.js`) ships the rules; this adds the type-aware setting.
   vitestTsConfig,
+  // The type-test layer (`*.test-d.*`): a self-contained vitest block scoped to
+  // type-test files. It only composes here, where `projectService` exists, so the
+  // type-requiring rules have type info. The base vitest layer excludes these
+  // files, so this is the sole place they are linted. See ADR-0005.
+  vitestTypeTestConfig,
   // Re-apply curated rules after intermediate configs so our tunings win.
   { rules },
   { files: [...TS_FILES], rules: { ...tsRules, ...tsCheckedRules } },

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -90,6 +90,53 @@ describe('vitest typecheck rides with projectService — TS test files only', ()
   });
 });
 
+describe('type-test files (*.test-d.ts) are linted only in the type-aware layer', () => {
+  // Type tests need `typecheck` + `projectService` to be meaningful, both of
+  // which live only in ./typescript+. The base (.) export must leave them with
+  // no vitest layer at all; ./typescript lints them with typecheck on, minus the
+  // structural rules that misfire on type tests (require-hook, the expect-group
+  // padding). See ADR-0005.
+  it('gives a -d file no vitest rules and no typecheck under the base (.) export', async () => {
+    const typeTest = await resolveConfig('.', FIXTURES.typeTest);
+
+    expect(severityOf(typeTest, 'vitest/prefer-to-be')).toBe('absent');
+    expect(typeTest.settings?.vitest?.typecheck).toBeUndefined();
+  });
+
+  it('lints a -d file with the curated vitest rules and typecheck under ./typescript', async () => {
+    const typeTest = await resolveConfig('./typescript', FIXTURES.typeTest);
+
+    expect(severityOf(typeTest, 'vitest/prefer-to-be')).toBe('error');
+    expect(typeTest.settings?.vitest?.typecheck).toBe(true);
+  });
+
+  it('turns off the rules that misfire on type tests, on -d files only', async () => {
+    const typeTest = await resolveConfig('./typescript', FIXTURES.typeTest);
+    const test = await resolveConfig('./typescript', FIXTURES.test);
+
+    expect(severityOf(typeTest, 'vitest/require-hook')).toBe('off');
+    expect(severityOf(typeTest, 'vitest/padding-around-expect-groups')).toBe('off');
+
+    // The deny-list is scoped to type-test files: runtime test files keep them.
+    expect(severityOf(test, 'vitest/require-hook')).toBe('error');
+    expect(severityOf(test, 'vitest/padding-around-expect-groups')).toBe('error');
+  });
+
+  it('keeps rules triage suspected but that do not misfire (e.g. require-top-level-describe)', async () => {
+    const typeTest = await resolveConfig('./typescript', FIXTURES.typeTest);
+
+    expect(severityOf(typeTest, 'vitest/require-top-level-describe')).toBe('error');
+    expect(severityOf(typeTest, 'vitest/consistent-test-filename')).toBe('error');
+  });
+
+  it('propagates to exports that layer on ./typescript (e.g. ./react)', async () => {
+    const typeTest = await resolveConfig('./react', FIXTURES.typeTest);
+
+    expect(severityOf(typeTest, 'vitest/prefer-to-be')).toBe('error');
+    expect(typeTest.settings?.vitest?.typecheck).toBe(true);
+  });
+});
+
 describe('curated tunings win over the presets they layer on top of', () => {
   it('keeps @typescript-eslint/array-type at array-simple over the stylistic preset', async () => {
     const ts = await resolveConfig('./typescript', FIXTURES.ts);

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -135,6 +135,18 @@ describe('type-test files (*.test-d.ts) are linted only in the type-aware layer'
     expect(severityOf(typeTest, 'vitest/prefer-to-be')).toBe('error');
     expect(typeTest.settings?.vitest?.typecheck).toBe(true);
   });
+
+  it('allows devDependency imports (e.g. vitest) in type-test files', async () => {
+    // The import layer (`import-x/no-extraneous-dependencies`) applies on every
+    // export, independent of the type-aware-only vitest scoping. Its
+    // devDependencies allowlist must include the type-test glob, or a colocated
+    // `src/a.test-d.ts` importing vitest's `expectTypeOf` (a devDependency) is
+    // wrongly flagged as extraneous in a consumer project.
+    const typeTest = await resolveConfig('./typescript', FIXTURES.typeTest);
+    const allowed = optionsOf(typeTest, 'import-x/no-extraneous-dependencies')?.devDependencies;
+
+    expect(allowed).toContain('**/*.{test,spec}-d.{ts,tsx,mts,cts}');
+  });
 });
 
 describe('curated tunings win over the presets they layer on top of', () => {

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -103,6 +103,29 @@ describe('type-test files (*.test-d.ts) are linted only in the type-aware layer'
     expect(typeTest.settings?.vitest?.typecheck).toBeUndefined();
   });
 
+  it('keeps a __tests__/-located -d file out of the runtime layer under base (.)', async () => {
+    // A `-d` file under `__tests__/` matches the runtime `TEST_FILES` dir glob,
+    // so only the runtime layer's `ignores: [...TYPE_TEST_FILES]` keeps it out of
+    // the base layer (where it would misfire — vitest rules with no typecheck).
+    // The `src/a.test-d.ts` fixture above can't catch a dropped `ignores`: it
+    // never matches `TEST_FILES`, so it resolves to no vitest rules regardless.
+    const typeTest = await resolveConfig('.', FIXTURES.typeTestInDir);
+
+    expect(severityOf(typeTest, 'vitest/prefer-to-be')).toBe('absent');
+    expect(typeTest.settings?.vitest?.typecheck).toBeUndefined();
+  });
+
+  it('governs a __tests__/-located -d file by the type-aware block under ./typescript', async () => {
+    // Wherever it sits, a `-d` file is linted by exactly one block: the type-aware
+    // one. Under `__tests__/` it also matches the runtime globs, so this pins that
+    // the type-test treatment (rules + typecheck) still wins via the `ignores`.
+    const typeTest = await resolveConfig('./typescript', FIXTURES.typeTestInDir);
+
+    expect(severityOf(typeTest, 'vitest/prefer-to-be')).toBe('error');
+    expect(typeTest.settings?.vitest?.typecheck).toBe(true);
+    expect(severityOf(typeTest, 'vitest/require-hook')).toBe('off');
+  });
+
   it('lints a -d file with the curated vitest rules and typecheck under ./typescript', async () => {
     const typeTest = await resolveConfig('./typescript', FIXTURES.typeTest);
 

--- a/packages/eslint-config/test/helpers.js
+++ b/packages/eslint-config/test/helpers.js
@@ -62,9 +62,12 @@ export const PLUGIN_EXPORTS = [
  * config globs. `configFile` and `script` hit the two distinct `NODE_FILES`
  * patterns (a `*.config.*` file and a path under `scripts/`); `test` and
  * `testJs` hit the `TEST_FILES` pattern (a TS and a JS test file — the pair that
- * pins the vitest `typecheck` setting to TS test files only). `typeTest` hits the
- * `TYPE_TEST_FILES` pattern (a `*.test-d.ts` type-test file — linted by the vitest
- * layer only under the type-aware exports, never under base `.`).
+ * pins the vitest `typecheck` setting to TS test files only). `typeTest` and
+ * `typeTestInDir` both hit the `TYPE_TEST_FILES` pattern (a `*.test-d.ts` type-test
+ * file — linted by the vitest layer only under the type-aware exports, never under
+ * base `.`); `typeTestInDir` sits under `__tests__/`, the one place a `-d` file
+ * also matches the runtime `TEST_FILES` dir glob, so it exercises the runtime
+ * layer's `ignores` that keeps the overlap out of the base layer.
  */
 export const FIXTURES = {
   js: 'src/a.js',
@@ -75,6 +78,7 @@ export const FIXTURES = {
   test: 'src/a.test.ts',
   testJs: 'src/a.test.js',
   typeTest: 'src/a.test-d.ts',
+  typeTestInDir: 'src/__tests__/a.test-d.ts',
 };
 
 /**

--- a/packages/eslint-config/test/helpers.js
+++ b/packages/eslint-config/test/helpers.js
@@ -62,7 +62,9 @@ export const PLUGIN_EXPORTS = [
  * config globs. `configFile` and `script` hit the two distinct `NODE_FILES`
  * patterns (a `*.config.*` file and a path under `scripts/`); `test` and
  * `testJs` hit the `TEST_FILES` pattern (a TS and a JS test file — the pair that
- * pins the vitest `typecheck` setting to TS test files only).
+ * pins the vitest `typecheck` setting to TS test files only). `typeTest` hits the
+ * `TYPE_TEST_FILES` pattern (a `*.test-d.ts` type-test file — linted by the vitest
+ * layer only under the type-aware exports, never under base `.`).
  */
 export const FIXTURES = {
   js: 'src/a.js',
@@ -72,6 +74,7 @@ export const FIXTURES = {
   script: 'scripts/x.ts',
   test: 'src/a.test.ts',
   testJs: 'src/a.test.js',
+  typeTest: 'src/a.test-d.ts',
 };
 
 /**


### PR DESCRIPTION
Closes #113.

## Problem

`*.test-d.ts` files — the home of `expectTypeOf`/`assertType` — never reached the vitest layer. `TEST_FILES` matches `*.{test,spec}.*` and `**/__tests__/**`, but not vitest's `-d` type-test convention. So `settings.vitest.typecheck: true`, which exists precisely to make the vitest rules type-test-aware, only ever altered behaviour on regular `*.test.ts` files; genuine type-test files got no vitest linting.

## Fix

Type-test files are now linted, but **only under the type-aware exports** (`./typescript`, `./browser`, `./react`, `./next`).

- **`file-patterns.js`** — new `TYPE_TEST_FILES = ['**/*.{test,spec}-d.{ts,tsx,mts,cts}']` (vitest's `-d` suffix; TS-only, mirroring `TS_TEST_FILES`).
- **`vitest.js`** — extract the curated rules to a shared const; the runtime `config` now `ignores` `-d` files; new `tsTypeTestConfig` export registers the plugin + globals, applies the curated rules + `typecheck: true`, **minus** the deny-list.
- **`typescript.js`** — compose `tsTypeTestConfig` right after the `projectService`/`vitestTsConfig` blocks (the only place type info is guaranteed).

### Why type-aware only

The type-requiring vitest rules (e.g. `vitest/valid-title`) and `expect-expect`'s recognition of type assertions only work where `typecheck` + `projectService` exist. Linting `-d` files under the base `.` export would misfire (`expect-expect` flags every bare-`expectTypeOf` file as assertion-less) or crash. So the base layer excludes them outright — under base `.`, a `-d` file carries zero vitest rules.

### The deny-list (established empirically, not guessed)

Audited the full curated set against both idiomatic type-test styles. Only two rules misfire and are turned off for `-d` files:

| Rule | Verdict |
|---|---|
| `require-hook` | misfires (bare top-level `expectTypeOf` → "should be in a hook") → **off** |
| `padding-around-expect-groups` | misfires (treats a type assertion as a runtime expect group) → **off** |
| `consistent-test-filename` | ✅ no misfire — self-skips `-d` via its `allTestPattern` gate |
| `require-top-level-describe` | ✅ no misfire — only fires on `test()` outside `describe`, same as runtime |

This corrects the triage note in #113, which over-counted the misfires.

## Testing

- **Resolved-config tests** (ADR-0003): a `typeTest` fixture asserts type-aware-only scoping, `typecheck: true`, the deny-list `off` on `-d` files only (runtime tests keep them on), and the non-misfiring rules staying on. **71/71 pass.**
- **End-to-end with real `projectService`**: linting a real bare-style `*.test-d.ts` exits 1 (findings, not the exit-2 crash) with no `require-hook`/`padding`/`expect-expect` misfires — confirming the deny-list and `typecheck` recognition work in practice.
- Full repo `test`, `lint`, `format:check`, `lint:md` all green.

## Release & docs

- **Minor** changeset — adds a new linted file class, which can surface new lint errors in a consumer's CI.
- New `CONTEXT.md` glossary term **Type-test file**; new **ADR-0005** records the type-aware-only scoping and the empirical deny-list.

Builds on #114 (the `typecheck` relocation); that fix must stay in place for the type-aware block to be crash-free by construction.