### PR TITLE
docs: refresh agent instructions to match current architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ The `*TypeCheckedOnly` presets ship "global" blocks that disable corresponding c
 
 Optional plugins exported separately: `plugins/graphql`, `plugins/jsdoc-required`, `plugins/playwright`, `plugins/tailwindcss`, `plugins/turbo`.
 
-Entry points pass raw layers to a single composer (`composeConfig` in `src/lib/compose.js`; ADR-0007), which appends the curated tunings and prettier tail exactly once, last — never spread an already-terminated sibling export into another entry point's layers. Plugin configs live in `src/plugins/` and are built with the `definePlugin` helper (`src/lib/define-plugin.js`; ADR-0008), which applies the block-naming convention (ADR-0009). File globs and extension lists are centralized in `src/lib/file-patterns.js` (browser globals in `src/lib/browser-globals.js`).
+Entry points pass raw layers to a single composer (`composeConfig` in `src/lib/compose.js`; ADR-0007), which appends the curated tunings and prettier tail exactly once, last — never spread an already-terminated sibling export into another entry point's layers. Plugin configs live in `src/plugins/`. Wrappers that are a single flat-config block registering a single plugin are built with the `definePlugin` helper (`src/lib/define-plugin.js`; ADR-0008), which applies the block-naming convention (ADR-0009); the structurally irreducible ones (`import`, `vitest`, `jsdoc`, `jsdoc-required`, `graphql`, `testing-library`) are intentionally hand-rolled. File globs and extension lists are centralized in `src/lib/file-patterns.js` (browser globals in `src/lib/browser-globals.js`).
 
 ### Other Packages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ pnpm run lint:md                      # markdownlint over all *.md files
 pnpm run lint:md:fix                  # markdownlint auto-fix
 pnpm run lint:actions                 # actionlint over GitHub Actions workflows
 pnpm run test                         # Run package test suites (via Turborepo)
+pnpm run test:affected                # Test only packages affected by changes
 pnpm run format                       # Fix formatting across the repo (root Prettier)
 pnpm run format:check                 # Check formatting across the repo (root Prettier)
 pnpm changeset                        # Create a changeset for versioning
@@ -77,16 +78,16 @@ Uses **ESLint flat config** format (ESLint 10+). Configs compose as arrays via l
 
 The `*TypeCheckedOnly` presets ship "global" blocks that disable corresponding core ESLint rules everywhere. `typescript.js` scopes those blocks to TS files only (via `scopeToTs`), so `.js` files keep their core-rule coverage from `base.js`.
 
-Optional plugins exported separately: `plugins/graphql`, `plugins/playwright`, `plugins/tailwindcss`, `plugins/turbo`.
+Optional plugins exported separately: `plugins/graphql`, `plugins/jsdoc-required`, `plugins/playwright`, `plugins/tailwindcss`, `plugins/turbo`.
 
-Plugin configs live in `src/plugins/` and follow a consistent pattern: import plugin, define config object with files/rules/plugins, export default. File globs and extension lists are centralized in `src/lib/file-patterns.js` (browser globals in `src/lib/browser-globals.js`).
+Entry points pass raw layers to a single composer (`composeConfig` in `src/lib/compose.js`; ADR-0007), which appends the curated tunings and prettier tail exactly once, last — never spread an already-terminated sibling export into another entry point's layers. Plugin configs live in `src/plugins/` and are built with the `definePlugin` helper (`src/lib/define-plugin.js`; ADR-0008), which applies the block-naming convention (ADR-0009). File globs and extension lists are centralized in `src/lib/file-patterns.js` (browser globals in `src/lib/browser-globals.js`).
 
 ### Other Packages
 
 - **prettier-config** — Single quotes, trailing commas everywhere
 - **stylelint-config** — Extends standard-scss + recess-order; plugins for browser compat, performance, strict values, nesting
 - **commitlint-config** — Extends config-conventional; enforces 100-char body line length
-- **tsconfig** — 4 environment×emit primitives over an internal `base` kernel: `node` (the `.` default) and `browser` are libraries (`tsc` emits, `nodenext`); `node-app` and `browser-app` are apps (`noEmit`, bundler resolution). No framework configs — consumers compose a primitive with the framework's own config (see `packages/tsconfig/README.md`; ADR-0001)
+- **tsconfig** — 4 environment×emit primitives composed from internal fragments (`base` + `env-node`/`env-browser` + `emit-library`/`emit-app`): `node` (the `.` default) and `browser` are libraries (`tsc` emits, `nodenext`); `node-app` and `browser-app` are apps (`noEmit`, bundler resolution). No framework configs — consumers compose a primitive with the framework's own config (see `packages/tsconfig/README.md`; ADR-0001)
 - **browserslist-config** — Default (a single rolling, modern query `last 2 years and not dead and fully supports es6-module`, landing at ~Baseline "newly"; see ADR-0004) and Node (maintained versions)
 
 ## CI


### PR DESCRIPTION
## Summary

An audit of `AGENTS.md` (`CLAUDE.md`) against the current codebase found a few sections left stale by recent refactors. This PR brings them back in line:

- **ESLint composition** — the plugin-pattern paragraph predated the single-composer refactor; it now describes `composeConfig` (ADR-0007), the `definePlugin` helper (ADR-0008), and the block-naming convention (ADR-0009), including the never-spread-a-terminated-sibling-export gotcha.
- **Optional plugin exports** — adds the missing `plugins/jsdoc-required` entry point.
- **tsconfig** — updates "over an internal `base` kernel" to the composable fragments introduced in #119 (`base` + `env-node`/`env-browser` + `emit-library`/`emit-app`).
- **Commands** — documents `pnpm run test:affected` alongside the existing `lint:affected`.

Docs-only; no changeset needed.