### PR TITLE
chore(deps): pin changesets js-yaml to patched 3.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Review dependencies
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # GHSA-h67p-54hq-rp68 (js-yaml merge-key DoS): the advisory's "<= 4.1.1" range still
+          # flags js-yaml@3.15.0, which actually backports the fix (see pnpm-workspace.yaml
+          # overrides). 4.x isn't reachable here (read-yaml-file needs the removed safeLoad).
+          # Remove once the advisory records a 3.x patched version, or @manypkg drops read-yaml-file.
+          allow-ghsas: GHSA-h67p-54hq-rp68
 
       - name: Lint pushed commit messages
         if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ catalogs:
 overrides:
   markdownlint-cli2>js-yaml: ^4.2.0
   markdownlint-cli2>markdown-it: ^14.2.0
-  read-yaml-file>js-yaml: ^3.15.0
+  read-yaml-file@1>js-yaml: ^3.15.0
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,7 @@ catalogs:
 overrides:
   markdownlint-cli2>js-yaml: ^4.2.0
   markdownlint-cli2>markdown-it: ^14.2.0
+  read-yaml-file>js-yaml: ^3.15.0
 
 importers:
 
@@ -2656,8 +2657,8 @@ packages:
     resolution: {integrity: sha512-/c+n06zvqFQGxdz1BbElF7S3nEghjNchLN1TjQnk2j10HYDaUc57rcvl6BbnziTx8NQmrg0JOs/iwRpvcYaxjQ==}
     engines: {node: '>=18.20'}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -6794,7 +6795,7 @@ snapshots:
 
   js-types@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -7458,7 +7459,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,13 +6,19 @@ allowBuilds:
   unrs-resolver: true
 
 overrides:
-  # Security pins for vulnerable transitive deps of markdownlint-cli2@0.22.1 (latest, which
-  # still pins the vulnerable versions). Both are quadratic-complexity DoS, dev-only scope.
-  # js-yaml 4.1.1 -> GHSA-h67p-54hq-rp68; markdown-it 14.1.1 -> GHSA-6v5v-wf23-fmfq.
-  # Scoped to markdownlint-cli2's subtree so changesets' js-yaml@3.x stays untouched.
-  # Remove once markdownlint-cli2 bumps its pins.
+  # Security pins for vulnerable transitive deps. All quadratic-complexity DoS, dev-only scope.
+  #
+  # markdownlint-cli2@0.22.1 (latest) pins vulnerable js-yaml@4.1.1 (GHSA-h67p-54hq-rp68) and
+  # markdown-it@14.1.1 (GHSA-6v5v-wf23-fmfq). Remove once markdownlint-cli2 bumps its pins.
   markdownlint-cli2>js-yaml: ^4.2.0
   markdownlint-cli2>markdown-it: ^14.2.0
+  #
+  # changesets -> read-yaml-file@1.1.0 pulls js-yaml@3.x, also covered by GHSA-h67p-54hq-rp68
+  # (range <= 4.1.1). 3.15.0 backports the fix (maxTotalMergeKeys) and keeps safeLoad(), which
+  # read-yaml-file needs -- it was removed in v4, so we can't go to 4.x on this path. Dependabot
+  # keeps the alert open because its range still covers 3.x, so alert #20 is dismissed as
+  # inaccurate. Remove once @manypkg/get-packages moves off read-yaml-file@1.x.
+  read-yaml-file>js-yaml: ^3.15.0
 
 catalog:
   '@changesets/changelog-github': ^0.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,10 +15,12 @@ overrides:
   #
   # changesets -> read-yaml-file@1.1.0 pulls js-yaml@3.x, also covered by GHSA-h67p-54hq-rp68
   # (range <= 4.1.1). 3.15.0 backports the fix (maxTotalMergeKeys) and keeps safeLoad(), which
-  # read-yaml-file needs -- it was removed in v4, so we can't go to 4.x on this path. Dependabot
-  # keeps the alert open because its range still covers 3.x, so alert #20 is dismissed as
-  # inaccurate. Remove once @manypkg/get-packages moves off read-yaml-file@1.x.
-  read-yaml-file>js-yaml: ^3.15.0
+  # read-yaml-file@1.x needs -- it was removed in v4, so we can't go to 4.x on this path.
+  # The @1 scope is deliberate: read-yaml-file v2.0.1+ moves to js-yaml 4.x (non-vulnerable), so
+  # pinning by parent major lets this override self-expire rather than forcing 3.x onto a 4.x
+  # subtree. Dependabot keeps the alert open because its range still covers 3.x, so alert #20 is
+  # dismissed as inaccurate. Remove once @manypkg/get-packages moves off read-yaml-file@1.x.
+  read-yaml-file@1>js-yaml: ^3.15.0
 
 catalog:
   '@changesets/changelog-github': ^0.7.0


### PR DESCRIPTION
## What

Resolve the remaining open Dependabot alert (#20, [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)) by pinning the second `js-yaml` instance — `changesets` → `read-yaml-file@1.1.0` → `js-yaml@3.x` — to the patched **`3.15.0`**, and allow-listing the advisory in dependency review (see "Why two changes" below).

Follow-up to #139, which fixed the `markdownlint-cli2` copy but left this one (the advisory's `<= 4.1.1` range covers all of 3.x, so the alert re-pinned to the surviving `3.14.2`).

## Changes

1. **`pnpm-workspace.yaml`** — override `read-yaml-file>js-yaml: ^3.15.0`.
2. **`.github/workflows/ci.yml`** — `allow-ghsas: GHSA-h67p-54hq-rp68` on `dependency-review-action`.

## Why 3.15.0 and not 4.x

- `read-yaml-file@1.1.0` calls `yaml.safeLoad()`, **removed in js-yaml 4** → forcing `^4.2.0` here would break `changeset version` at release time.
- **`js-yaml@3.15.0` (2026-06-27) is the backported fix** — it adds the same `maxTotalMergeKeys` guard as 5.x and keeps `safeLoad()`. Safe minor bump, zero API-compat risk.

## Why two changes (the allowlist)

GitHub's advisory records only `4.2.0` as patched, and its `<= 4.1.1` range still mathematically covers `3.15.0` — even though `3.15.0` *contains* the fix. So **both** GitHub gates reject it on metadata alone:

- **`dependency-review-action`** fails the PR → handled here by `allow-ghsas` (commented, with a removal condition).
- **Dependabot alert #20** won't auto-close → must be **dismissed as `inaccurate`** after merge (a dismissal does *not* satisfy the dependency-review gate, hence the allowlist too).

There is no js-yaml version reachable on this path that GitHub considers "patched", so a documented exception is unavoidable. Both the override and the allowlist should be removed once the advisory records a 3.x patched version, or `@manypkg/get-packages` drops `read-yaml-file@1.x`.

## Verification

- `pnpm install` → lockfile: `js-yaml@3.14.2` → `3.15.0`; no `3.x` copy below `3.15.0` remains.
- `pnpm changeset status` ✅ — confirms `read-yaml-file`'s `safeLoad` parses `pnpm-workspace.yaml` on 3.15.0.
- `pnpm why js-yaml` → only `3.15.0` (changesets) and `4.2.0` (markdownlint-cli2).
- CI green, including the **Review dependencies** step.

## After merge

Dismiss alert #20 as `inaccurate`:

```bash
gh api -X PATCH repos/benhigham/javascript/dependabot/alerts/20 \
  -f state=dismissed -f dismissed_reason=inaccurate \
  -f dismissed_comment="Patched via pnpm override (#141): js-yaml@3.15.0 backports the maxTotalMergeKeys fix and retains safeLoad(). The advisory's <= 4.1.1 range still covers 3.15.0, but that version contains the fix."
```

**No changeset** — transitive dev-only dep, not consumer-facing.
