### PR TITLE
fix(eslint-config): relax sonarjs/no-floating-point-equality in test files

### DIFF
--- a/.changeset/quiet-floats-in-tests.md
+++ b/.changeset/quiet-floats-in-tests.md
@@ -1,0 +1,5 @@
+---
+'@benhigham/eslint-config': patch
+---
+
+Relax `sonarjs/no-floating-point-equality` in test files. The rule flags any float-sensitive operand in an `expect().toBe()/toEqual()` (or a raw `===`), including a correct exact-literal fixture like `toBe(0.6)`, and it has no option to allow exact literals. In test code a genuinely-wrong float assertion fails loudly when the suite runs, so the rule's silent-drift value — the reason it earns its keep in source — is low there. It stays on for source files; suites that want the guard can re-enable it locally and reach for `toBeCloseTo`.

--- a/packages/eslint-config/src/plugins/vitest.js
+++ b/packages/eslint-config/src/plugins/vitest.js
@@ -97,6 +97,16 @@ const rules = {
   // (`toBe(undefined)`, `mockReturnValue(undefined)`). The `unicorn` plugin is
   // already registered for these files by `unicorn.js`.
   'unicorn/no-useless-undefined': 'off',
+
+  // Also not a vitest rule, relaxed here for the same reason:
+  // `sonarjs/no-floating-point-equality` flags any float-sensitive operand in an
+  // `expect().toBe()/toEqual()` (or a raw `===`), including a correct exact-literal
+  // fixture like `toBe(0.6)`. The rule has no option to allow exact literals, and a
+  // genuinely-wrong float assertion fails loudly when the test runs — so its
+  // silent-drift value, the reason it earns its keep in source, is low here.
+  // Numeric or Node-library suites can re-enable it and reach for `toBeCloseTo`.
+  // The `sonarjs` plugin is already registered for these files by `base.js`.
+  'sonarjs/no-floating-point-equality': 'off',
 };
 
 /**

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -74,6 +74,24 @@ describe('the shipped vitest layer composes in, scoped to test files', () => {
   });
 });
 
+describe('the vitest layer relaxes sonarjs/no-floating-point-equality on test files', () => {
+  // Not a vitest rule, but the vitest layer turns it off on test files: it flags
+  // correct exact-literal assertions like `expect(x).toBe(0.6)`, has no option to
+  // allow them, and a wrong float assertion fails loudly at runtime anyway. The
+  // rule is AST-only (registered in base for all files), so it fires on JS test
+  // files too — the relaxation must reach both. Source files keep it, where its
+  // silent-drift catch earns its keep.
+  it('turns it off on TS and JS test files but keeps it on source, under base (.)', async () => {
+    const test = await resolveConfig('.', FIXTURES.test);
+    const testJs = await resolveConfig('.', FIXTURES.testJs);
+    const source = await resolveConfig('.', FIXTURES.ts);
+
+    expect(severityOf(test, 'sonarjs/no-floating-point-equality')).toBe('off');
+    expect(severityOf(testJs, 'sonarjs/no-floating-point-equality')).toBe('off');
+    expect(severityOf(source, 'sonarjs/no-floating-point-equality')).toBe('error');
+  });
+});
+
 describe('vitest typecheck rides with projectService — TS test files only', () => {
   // The setting makes type-aware vitest rules (e.g. vitest/valid-title) consult
   // parser type services, which only exist where projectService is set. It must


### PR DESCRIPTION
## What

Turn `sonarjs/no-floating-point-equality` **off in test files** in `@benhigham/eslint-config`, upstreaming an exemption that `benhigham/web` had added locally.

## Why

The rule (recommended `error` since sonarjs 4.1.0, already reaching consumers via `^4.0.0`) flags any float-sensitive operand in an `expect().toBe()/toEqual()` — or a raw `===` — including a **correct** exact-literal fixture like `expect(x).toBe(0.6)`. Verified against the installed plugin:

- It's **AST-only** (identical findings with/without type info) and registered in `base`, so it fires on **JS test files too**, under every export.
- It fires whenever *either* operand is float-sensitive (a non-binary-representable literal, a `const` traced to one, or float arithmetic) — even `expect(a).toBe(3)` when `a` is a float const.
- It has **no options and no autofix** — there's no "allow exact literals" knob, so `off` is the only lever. `toBeCloseTo` is its built-in escape hatch (correctly never flagged).

The justification for relaxing isn't "literals never drift" (the rule can't know that, and is often right). It's that in test code a genuinely-wrong float assertion **fails loudly when the suite runs**, so the rule's real value — catching *silent* drift — is low there. This matches the package's existing posture: the vitest layer already turns off `unicorn/no-useless-undefined` for the same "fires in test files" reason.

Accepted cost: this also silences the genuine `expect(0.1 + 0.2).toBe(0.3)` catch — but that's the one case that already fails at runtime. Numeric or Node-library suites can re-enable the rule locally and use `toBeCloseTo`.

## How

- Added `'sonarjs/no-floating-point-equality': 'off'` to the shared vitest `rules` (`src/plugins/vitest.js`), scoped to `TEST_FILES` (JS + TS), beside the analogous `unicorn/no-useless-undefined` relaxation, with a rationale comment.
- New resolved-config test (per ADR-0003): `off` on TS **and** JS test files, `error` on source, under base `.`.
- Patch changeset — the change only removes errors, so it can't break a consumer's CI.

## Follow-up (separate repo)

After release: bump `benhigham/web`'s pinned `@benhigham/eslint-config` (Renovate's fresh-release age-gate will hold it a few days), then remove the now-redundant web-local override. The import-x half of that plugin churn stays web-specific.

Ref: benhigham/web#247
