### PR TITLE
fix(eslint-config): relax two unicorn v71 assignment rules in test files

### DIFF
--- a/.changeset/hush-test-stubs.md
+++ b/.changeset/hush-test-stubs.md
@@ -1,0 +1,5 @@
+---
+'@benhigham/eslint-config': patch
+---
+
+Relax `unicorn/no-top-level-assignment-in-function` and `unicorn/no-global-object-property-assignment` in test files. Both are recommended `error` since unicorn v71 and expose no options, yet they fire on idiomatic Vitest setup: module-scope capture assigned in a `beforeEach` / stubbed-class constructor / `vi.mock` factory, and stubbing a browser global (`window.scrollBy = spy`). A genuinely-wrong stub fails loudly when the suite runs, so the rules' silent-drift value — the reason they earn their keep in source — is low there. They stay on for source files; suites that want the guard can re-enable them locally.

--- a/packages/eslint-config/src/plugins/vitest.js
+++ b/packages/eslint-config/src/plugins/vitest.js
@@ -107,6 +107,19 @@ const rules = {
   // Numeric or Node-library suites can re-enable it and reach for `toBeCloseTo`.
   // The `sonarjs` plugin is already registered for these files by `base.js`.
   'sonarjs/no-floating-point-equality': 'off',
+
+  // Two more unicorn rules (recommended `error` since v71, no options), relaxed
+  // here for the same "fires in test files" reason. The `unicorn` plugin is
+  // already registered for these files by `unicorn.js`.
+  // - `no-top-level-assignment-in-function`: module-scope capture assigned in a
+  //   `beforeEach` / stubbed-class constructor / `vi.mock` factory is idiomatic
+  //   test setup, not the action-at-a-distance the rule guards against in source.
+  // - `no-global-object-property-assignment`: stubbing a browser global
+  //   (`window.scrollBy = spy`) is a common, deliberate test-setup shortcut.
+  // A genuinely-wrong stub fails loudly when the suite runs; suites wanting the
+  // guard can re-enable it locally.
+  'unicorn/no-top-level-assignment-in-function': 'off',
+  'unicorn/no-global-object-property-assignment': 'off',
 };
 
 /**

--- a/packages/eslint-config/test/composition.test.js
+++ b/packages/eslint-config/test/composition.test.js
@@ -92,6 +92,32 @@ describe('the vitest layer relaxes sonarjs/no-floating-point-equality on test fi
   });
 });
 
+describe('the vitest layer relaxes two unicorn v71 test-setup rules on test files', () => {
+  // Not vitest rules, but the vitest layer turns them off on test files. Both are
+  // recommended `error` in unicorn v71 and expose no options, so `off` scoped to
+  // test files is the only lever. `no-top-level-assignment-in-function` flags the
+  // idiomatic module-scope capture assigned in `beforeEach` / a stubbed-class
+  // constructor / a `vi.mock` factory; `no-global-object-property-assignment`
+  // flags stubbing a browser global (`window.scrollBy = spy`). Both are AST-only
+  // and registered in the base layer for all files, so they fire on JS test files
+  // too — the relaxation must reach both. Source files keep them at `error`.
+  it.each([
+    'unicorn/no-top-level-assignment-in-function',
+    'unicorn/no-global-object-property-assignment',
+  ])(
+    'turns %s off on TS and JS test files but keeps it on source, under base (.)',
+    async (rule) => {
+      const test = await resolveConfig('.', FIXTURES.test);
+      const testJs = await resolveConfig('.', FIXTURES.testJs);
+      const source = await resolveConfig('.', FIXTURES.ts);
+
+      expect(severityOf(test, rule)).toBe('off');
+      expect(severityOf(testJs, rule)).toBe('off');
+      expect(severityOf(source, rule)).toBe('error');
+    },
+  );
+});
+
 describe('vitest typecheck rides with projectService — TS test files only', () => {
   // The setting makes type-aware vitest rules (e.g. vitest/valid-title) consult
   // parser type services, which only exist where projectService is set. It must


### PR DESCRIPTION
## What

Turn two `eslint-plugin-unicorn` v71 rules **off in test files** in `@benhigham/eslint-config`:

- `unicorn/no-top-level-assignment-in-function`
- `unicorn/no-global-object-property-assignment`

## Why

Both are `recommended: error` in unicorn v71 (reaching consumers via the base layer) and expose **no options**, yet they fire almost exclusively on idiomatic Vitest setup:

- **`no-top-level-assignment-in-function`** — module-scope capture assigned in a `beforeEach` / stubbed-class constructor / `vi.mock` factory (the standard way to reach into a mock).
- **`no-global-object-property-assignment`** — stubbing a browser global, e.g. `window.scrollBy = spy`.

In `benhigham/web` these two rules alone produced **39 findings across 8 test files**, every one a false positive on setup code. A genuinely-wrong stub fails loudly when the suite runs, so the rules' silent-drift value — the reason they earn their keep in source — is low in tests. They stay `error` on source files; suites that want the guard can re-enable them locally.

This follows the settled posture for `sonarjs/no-floating-point-equality` (#147) and `unicorn/no-useless-undefined`: relax in test files only, because there's no narrower lever.

## How

- Added both toggles to the shared vitest `rules` (`src/plugins/vitest.js`), scoped to `TEST_FILES`, beside the existing `unicorn/no-useless-undefined` / `sonarjs/no-floating-point-equality` relaxations, each with a rationale comment.
- New resolved-config test (per ADR-0003): both rules `off` on TS **and** JS test files, still `error` on a source path, under base `.`.
- **Patch** changeset — the change only removes errors, so it can't break a consumer's CI. No ADR (trivially reversible toggle, documented by the inline comments, matching the unicorn/sonarjs precedents).

## Verification

- Test-first (red → green); full `@benhigham/eslint-config` suite: **109 tests pass**.
- Verified against installed `eslint-plugin-unicorn@^71`: both rules are `recommended: error` with empty schemas.
- Two-axis code review (standards + spec): 0 findings.

## Sequencing (web follow-up, separate repo)

`benhigham/web` has a documented test-scoped override for both rules pending this. Once released: bump web's pinned `@benhigham/eslint-config` (mind the fresh-release age-gate), then remove the local override.

Closes #152
